### PR TITLE
Recurrence encoding fix

### DIFF
--- a/src/drive/cipher_manager.py
+++ b/src/drive/cipher_manager.py
@@ -2,6 +2,7 @@ import multiprocessing as mp
 from utils.logging import get_colored_logger
 import os
 from typing import Iterable, Any
+import json
 
 from drive.drive_uploader import DriveUploader, DriveUploaderConfig
 from drive.cipher_producer import CipherProducer
@@ -89,12 +90,7 @@ class CipherManager:
 
 		count_fed = 0
 		try:
-			for split, text_data in self.stream:
-				self.job_queue.put((split, text_data))
-				count_fed += 1
-
-				if count_fed % 1000 == 0:
-					log.info(f"Fed {count_fed} texts to workers...")
+			self._feeder_stream()
 
 		except KeyboardInterrupt:
 			log.warning("Job interrupted! Stopping...")
@@ -108,14 +104,49 @@ class CipherManager:
 		for p in workers:
 			p.join()
 
+		self._upload_metadata()
 		self.result_queue.put(self.SENTINEL)
 
 		uploader.join()
 
-		peak_value = self.max_symbol_id.value
-
 		log.info("=" * 40)
 		log.info("JOB COMPLETE")
 		log.info(f"Total ciphers fed: {count_fed}")
-		log.info(f"Peak homophone ID (Vocab Size): {peak_value}")
+		log.info(f"Peak homophone ID (Vocab Size): {self.max_symbol_id.value}")
 		log.info("=" * 40)
+
+	def _upload_metadata(self) -> None:
+		"""Upload the metadata file to Google Drive.
+
+		This method uploads the metadata file to Google Drive, which contains
+		the peak homophone ID (Vocab Size) of the generated ciphers.
+
+		"""
+		log.info("Uploading metadata file...")
+		metadata_filename = "metadata.json"
+		metadata_bytes = json.dumps({"max_symbol_id": self.max_symbol_id.value}).encode(
+			"utf-8",
+		)
+		self.result_queue.put(("metadata", metadata_filename, metadata_bytes))
+
+	def _feeder_stream(self) -> None:
+		"""Feed the ciphers to the workers using the job queue.
+
+		This method feeds the ciphers to the workers using the job queue. It
+		handles routing by split and error handling.
+
+		Raises:
+			Exception: If any error occurs during the execution.
+
+		"""
+		log.info("Feeding ciphers to workers...")
+
+		for count_fed, (split, text_data) in enumerate(self.stream):
+			self.job_queue.put((split, text_data))
+
+			if count_fed % 1000 == 0:
+				log.info(f"Fed {count_fed} texts to workers...")
+
+			if count_fed >= self.total_count:
+				log.info(f"Target of {self.total_count} reached. Stopping feeder.")
+				break

--- a/src/drive/cipher_manager.py
+++ b/src/drive/cipher_manager.py
@@ -55,6 +55,9 @@ class CipherManager:
 		self.job_queue = self.manager.Queue(maxsize=1000)
 		self.result_queue = self.manager.Queue()
 
+		self.max_symbol_id = self.manager.Value("i", 0)
+		self.max_lock = self.manager.Lock()
+
 	def execute(self) -> None:
 		"""Execute the cipher generation process."""
 		log.info(
@@ -75,8 +78,8 @@ class CipherManager:
 		workers = []
 		for i in range(self.num_workers):
 			p = CipherProducer(
-				input_queue=self.job_queue,  # type: ignore
-				output_queue=self.result_queue,  # type: ignore
+				queues=(self.job_queue, self.result_queue),  # type: ignore
+				tracker=(self.max_symbol_id, self.max_lock),
 				name=f"Worker-{i + 1}",
 			)
 			workers.append(p)
@@ -108,4 +111,11 @@ class CipherManager:
 		self.result_queue.put(self.SENTINEL)
 
 		uploader.join()
-		log.info("Job complete.")
+
+		peak_value = self.max_symbol_id.value
+
+		log.info("=" * 40)
+		log.info("JOB COMPLETE")
+		log.info(f"Total ciphers fed: {count_fed}")
+		log.info(f"Peak homophone ID (Vocab Size): {peak_value}")
+		log.info("=" * 40)

--- a/src/drive/cipher_producer.py
+++ b/src/drive/cipher_producer.py
@@ -4,6 +4,9 @@ import queue
 from typing import Any
 from multiprocessing.queues import Queue as MPQueue
 
+from multiprocessing.managers import ValueProxy
+from threading import Lock
+
 from utils.drive import create_cipher_json
 from utils.logging import get_colored_logger
 from encipherment.cipher import SubstitutionCipher, HomophonicCipher
@@ -25,8 +28,8 @@ class CipherProducer(mp.Process):
 
 	def __init__(
 		self,
-		input_queue: MPQueue[Any],
-		output_queue: MPQueue[Any],
+		queues: tuple[MPQueue[Any], MPQueue[Any]],
+		tracker: tuple[ValueProxy[int], Lock],
 		*args: Any,
 		**kwargs: Any,
 	) -> None:
@@ -40,8 +43,8 @@ class CipherProducer(mp.Process):
 
 		"""
 		super().__init__(*args, **kwargs)
-		self.input_queue = input_queue
-		self.output_queue = output_queue
+		self.input_queue, self.output_queue = queues
+		self.max_symbol_tracker, self.max_lock = tracker
 
 	def run(self) -> None:
 		"""Execute the cipher generation process loop."""
@@ -63,6 +66,8 @@ class CipherProducer(mp.Process):
 				if cipher is None:
 					continue
 
+				self._update_max_symbol_id(cipher.num_symbols)
+
 				_, file_bytes = create_cipher_json(cipher)
 
 				filename = (
@@ -79,6 +84,20 @@ class CipherProducer(mp.Process):
 
 		log.info(f"{process_name} finished generation.")
 
+	def _update_max_symbol_id(self, symbol_id: int) -> None:
+		"""Update the max symbol ID tracker.
+
+		Args:
+			symbol_id (int): The new symbol ID to update the tracker with.
+
+		"""
+		if self.max_symbol_tracker is None or self.max_lock is None:
+			return
+
+		with self.max_lock:
+			if symbol_id > self.max_symbol_tracker.value:
+				self.max_symbol_tracker.value = symbol_id
+
 	def generate_cipher(self, text: TextStream) -> SubstitutionCipher | None:
 		"""Generate a cipher from the provided text string.
 
@@ -89,7 +108,6 @@ class CipherProducer(mp.Process):
 		try:
 			cipher = HomophonicCipher(text)
 
-			cipher.generate_difficulty()
 			cipher.generate_key()
 			cipher.encipher()
 

--- a/src/drive/cipher_producer.py
+++ b/src/drive/cipher_producer.py
@@ -23,6 +23,8 @@ class CipherProducer(mp.Process):
 		input_queue (MPQueue[Any]): Queue containing tuples of (split, text_data).
 		output_queue (MPQueue[Any]): Queue to send tuples of
 			(split, filename, file_bytes).
+		max_symbol_tracker (tuple[ValueProxy[int], Lock]): A tuple containing a
+			ValueProxy object and a Lock object to track the maximum symbol ID.
 
 	"""
 
@@ -36,8 +38,10 @@ class CipherProducer(mp.Process):
 		"""Initialize the CipherProducer.
 
 		Args:
-			input_queue (MPQueue): Queue to receive split and text chunks from.
-			output_queue (MPQueue): Queue to send split, filename, and bytes to.
+			queues (tuple[MPQueue[Any], MPQueue[Any]]): A tuple containing two queues:
+				input_queue and output_queue.
+			tracker (tuple[ValueProxy[int], Lock]): A tuple containing a ValueProxy
+				object and a Lock object to track the maximum symbol ID.
 			*args: Additional arguments.
 			**kwargs: Additional keyword arguments.
 

--- a/src/drive/drive_uploader.py
+++ b/src/drive/drive_uploader.py
@@ -108,7 +108,6 @@ class DriveUploader(mp.Process):
 		self.total_ciphers = config.total_ciphers
 		self.drive_service = None
 		self.uploaded_count = 0
-		self.batch_states = {split: BatchState(split) for split in self.split_folders}
 
 	def run(self) -> None:
 		"""Execute the cipher upload process.
@@ -120,12 +119,17 @@ class DriveUploader(mp.Process):
 			Exception: If any error occurs during the execution.
 
 		"""
+		self.batch_states = {
+			split: BatchState(split)
+			for split in self.split_folders
+			if split != "metadata"
+		}
 		process_name = self.name
 		if not self._authenticate_service():
 			return
 
 		with tqdm(total=self.total_ciphers, desc="Total Ciphers Uploaded") as pbar:
-			while self.uploaded_count < self.total_ciphers:
+			while True:
 				try:
 					item = self.queue.get(timeout=5)
 				except queue.Empty:
@@ -136,7 +140,9 @@ class DriveUploader(mp.Process):
 					break
 
 				split, filename, file_bytes = item
-				if split in self.batch_states:
+				if split == "metadata":
+					self._upload_raw_file(split, filename, file_bytes)
+				elif split in self.batch_states:
 					self._process_cipher_item(split, filename, file_bytes, pbar)
 
 		log.info(
@@ -185,6 +191,41 @@ class DriveUploader(mp.Process):
 			bs.zip_buffer.close()
 			batch_filename = f"{split}_ciphers_batch_{bs.batch_num}.zip"
 			self.batch_states[split] = self._upload_batch(bs, pbar, batch_filename)
+
+	def _upload_raw_file(self, split: str, filename: str, file_bytes: bytes) -> None:
+		"""Upload a raw file directly to Google Drive without zipping.
+
+		Args:
+			split (str): The split identifier (e.g., 'metadata').
+			filename (str): The desired filename on Drive.
+			file_bytes (bytes): The raw file contents.
+
+		"""
+		folder_id = self.split_folders.get(split)
+		if not folder_id:
+			log.error(
+				f"Cannot upload {filename}: No folder ID found for split '{split}'",
+			)
+			return
+
+		try:
+			file_id = upload_to_drive(
+				self.drive_service,
+				file_bytes,
+				filename,
+				folder_id,
+			)
+
+			if file_id:
+				log.info(f"Uploaded raw file {filename} to {split} folder: {file_id}")
+			else:
+				log.error(f"FATAL: Failed to upload raw file {filename} to {split}.")
+
+		except Exception as e:
+			log.error(
+				f"FATAL: Unexpected error uploading raw file {filename}: {e}",
+				exc_info=True,
+			)
 
 	def _upload_all_final_batches(self, pbar: tqdm) -> None:
 		"""Upload any remaining partial batches for all configured splits.

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -23,10 +23,8 @@ class SubstitutionCipher(ABC):
 			or spaces.
 		difficulty (int): The difficulty level of the cipher (4-20).
 		key (dict): A dictionary mapping each letter to a list of its homophones.
-		ciphertext (str): The resulting ciphertext as a string of numbers separated
-			by spaces.
-		recurrence_encoding (str): A string representing the recurrence encoding of
-			the ciphertext.
+		ciphertext (str): The resulting ciphertext as a string of reccurence encoded
+			numbers separated by spaces.
 
 	Methods:
 		generate_key(): Generate a homophonic substitution cipher key based on a
@@ -57,31 +55,35 @@ class SubstitutionCipher(ABC):
 		self.num_symbols = 0
 		self.key = {}
 		self.ciphertext = ""
-		self.recurrence_encoding = ""
 		self.source_id = text_obj["source_id"]
 		self.source_name = text_obj["source_name"]
 		raise NotImplementedError("This is an abstract base class.")
 
-	def _generate_recurrence_encoding(self) -> str:
-		"""Generate recurrence encoding for the ciphertext based on the homophones used.
+	def _apply_recurrence_and_remap_key(self) -> None:
+		"""Apply recurrence encoding and remap the key using character keys."""
+		original_numbers = self.ciphertext.split()
+		new_ciphertext = []
+		symbol_map = {}
 
-		Each homophone is represented by a unique symbol, and the encoder gives the next
-		number each time a new symbol is encountered.
+		for symbol in original_numbers:
+			if symbol not in symbol_map:
+				symbol_map[symbol] = str(len(symbol_map) + 1)
+			new_ciphertext.append(symbol_map[symbol])
 
-		Example:
-			`83 45 12 123 45 -> 1 2 3 4 2`
+		self.ciphertext = " ".join(new_ciphertext)
+		self.recurrence_encoding = self.ciphertext
 
-		"""
-		ciphertext_numbers = self.ciphertext.split()
-		recurrence_encoding = []
-		encountered_symbols = {}
+		new_key = {}
+		for char, homophones in self.key.items():
+			remapped_homophones = [
+				int(symbol_map[str(h)]) 
+				for h in homophones 
+				if str(h) in symbol_map
+			]
+			
+			new_key[char] = remapped_homophones
 
-		for number in ciphertext_numbers:
-			if number not in encountered_symbols:
-				encountered_symbols[number] = len(encountered_symbols) + 1
-			recurrence_encoding.append(str(encountered_symbols[number]))
-
-		return " ".join(recurrence_encoding)
+		self.key = new_key
 
 	def __json__(self) -> dict:
 		"""Return a JSON-serializable representation of the Cipher object.
@@ -96,7 +98,7 @@ class SubstitutionCipher(ABC):
 			"num_symbols": self.num_symbols,
 			"difficulty": self.difficulty,
 			"key": self.key,
-			"ciphertext": self.recurrence_encoding,
+			"ciphertext": self.ciphertext,
 			"source_id": self.source_id,
 			"source_name": self.source_name,
 		}
@@ -113,7 +115,6 @@ class SubstitutionCipher(ABC):
 			Difficulty: {self.difficulty}
 			Key: {self.key}
 			Ciphertext: "{self.ciphertext}"
-			Recurrence Encoding: "{self.recurrence_encoding}")
 			'''
 
 	@abstractmethod
@@ -133,7 +134,6 @@ class SubstitutionCipher(ABC):
 		cipher = cls(data["plaintext"])
 		cipher.key = data["key"]
 		cipher.ciphertext = data["ciphertext"]
-		cipher.recurrence_encoding = data["recurrence_encoding"]
 		cipher.num_symbols = data["num_symbols"]
 		cipher.difficulty = data["difficulty"]
 		cipher.source_id = data["source_id"]
@@ -195,7 +195,6 @@ class HomophonicCipher(SubstitutionCipher):
 		self.num_symbols = 0
 		self.key: dict[str, list] = {}
 		self.ciphertext: str = ""
-		self.recurrence_encoding: str = ""
 		self.source_id = text_obj["source_id"]
 		self.source_name = text_obj["source_name"]
 
@@ -253,7 +252,8 @@ class HomophonicCipher(SubstitutionCipher):
 			ciphertext_numbers.append(str(homophones[char][ptr[char]]))
 			ptr[char] += 1
 		self.ciphertext = " ".join(ciphertext_numbers)
-		self.recurrence_encoding = self._generate_recurrence_encoding()
+
+		self._apply_recurrence_and_remap_key()
 		return self.ciphertext
 
 	def generate_difficulty(self) -> int:
@@ -307,9 +307,7 @@ class MonoalphabeticCipher(SubstitutionCipher):
 		self.num_symbols = 0
 		self.key = self.generate_key()
 		self.difficulty = 1
-		self.ciphertext = self.encipher()
-		self.recurrence_encoding = self._generate_recurrence_encoding()
-		self.ciphertext = self.recurrence_encoding
+		self.encipher()
 		self.source_id = text_obj["source_id"]
 		self.source_name = text_obj["source_name"]
 
@@ -348,4 +346,7 @@ class MonoalphabeticCipher(SubstitutionCipher):
 					str(self.key[char][0]),
 				)
 
-		return " ".join(ciphertext_numbers)
+		self.ciphertext = " ".join(ciphertext_numbers)
+		self._apply_recurrence_and_remap_key()
+  
+		return self.ciphertext

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -76,11 +76,11 @@ class SubstitutionCipher(ABC):
 		new_key = {}
 		for char, homophones in self.key.items():
 			remapped_homophones = [
-				int(symbol_map[str(h)]) 
-				for h in homophones 
+				int(symbol_map[str(h)])
+				for h in homophones
 				if str(h) in symbol_map
 			]
-			
+
 			new_key[char] = remapped_homophones
 
 		self.key = new_key
@@ -348,5 +348,5 @@ class MonoalphabeticCipher(SubstitutionCipher):
 
 		self.ciphertext = " ".join(ciphertext_numbers)
 		self._apply_recurrence_and_remap_key()
-  
+
 		return self.ciphertext

--- a/src/gen_training.py
+++ b/src/gen_training.py
@@ -9,6 +9,14 @@ if __name__ == "__main__":
 	folder_id_val = os.getenv("FOLDER_ID_VAL")
 	folder_id_test = os.getenv("FOLDER_ID_TEST")
 
+	folder_id_metadata = os.getenv("FOLDER_ID_METADATA")
+
+	if not folder_id_metadata:
+		raise OSError(
+			"FOLDER_ID_METADATA environment variable not set. "
+			"Please set it before running.",
+		)
+
 	if not folder_id_train:
 		raise OSError(
 			"FOLDER_ID_TRAIN environment variable not set. "
@@ -28,9 +36,10 @@ if __name__ == "__main__":
 	text_stream = get_text_stream()
 
 	config = {
-		"train": {"folder_id": folder_id_train, "count": 1_000_000},
-		"val": {"folder_id": folder_id_val, "count": 10_000},
-		"test": {"folder_id": folder_id_test, "count": 10_000},
+		"train": {"folder_id": folder_id_train, "count": 10},
+		"val": {"folder_id": folder_id_val, "count": 10},
+		"test": {"folder_id": folder_id_test, "count": 10},
+		"metadata": {"folder_id": folder_id_metadata, "count": 0},
 	}
 
 	manager = CipherManager(

--- a/src/main.py
+++ b/src/main.py
@@ -112,7 +112,6 @@ if __name__ == "__main__":  # pragma: no cover
 		z408.key = z408_key
 		z408.ciphertext = z408_cipher
 		z408.num_symbols = 54
-		z408._generate_recurrence_encoding()
 
 		save_cipher(cipher_data=z408, filename="z408.json")
 		pbar.update(1)

--- a/src/utils/cipher_conversion.py
+++ b/src/utils/cipher_conversion.py
@@ -180,11 +180,6 @@ class CipherConverter:
 		self._cipher.ciphertext = self.ciphertext
 		self._cipher.key = self.mappings  # type: ignore
 
-		if hasattr(self._cipher, "_generate_recurrence_encoding"):
-			self._cipher.recurrence_encoding = (
-				self._cipher._generate_recurrence_encoding()
-			)
-
 		return self._cipher
 
 	def _is_homophonic(self) -> bool:

--- a/test/drive/test_cipher_producer.py
+++ b/test/drive/test_cipher_producer.py
@@ -179,21 +179,21 @@ class TestCipherProducerRun:
 		mock_log.error.assert_called()
 		assert "Queue connection lost" in mock_log.error.call_args[0][0]
 		assert mock_input_q.get.call_count == 2
-  
-  
+
+
 class TestUpdateMaxSymbolId:
 	def test_update_when_new_id_is_greater(self, mock_tracker, mock_queues):
 		val_proxy, lock = mock_tracker
 		val_proxy.value = 5  # Initial state
-		
+
 		producer = CipherProducer(
 			queues=mock_queues,
 			tracker=mock_tracker,
 			name="TestProducer"
 		)
-		
+
 		producer._update_max_symbol_id(10)
-		
+
 		# The value should be updated to 10
 		assert val_proxy.value == 10
 		# Verify the lock was actually acquired
@@ -202,51 +202,51 @@ class TestUpdateMaxSymbolId:
 	def test_ignore_when_new_id_is_lesser_or_equal(self, mock_tracker, mock_queues):
 		val_proxy, lock = mock_tracker
 		val_proxy.value = 20  # Initial state is high
-		
+
 		producer = CipherProducer(
 			queues=mock_queues,
 			tracker=mock_tracker,
 			name="TestProducer"
 		)
-		
+
 		# Try a lesser value
 		producer._update_max_symbol_id(10)
 		assert val_proxy.value == 20
-		
+
 		# Try an equal value
 		producer._update_max_symbol_id(20)
 		assert val_proxy.value == 20
-		
+
 		# Lock should still be acquired both times to check the value safely
 		assert lock.__enter__.call_count == 2
 
 	def test_early_return_if_tracker_or_lock_is_none(self, mock_queues, mock_tracker):
 		_, lock = mock_tracker
-		
+
 		producer = CipherProducer(
 			queues=mock_queues,
 			tracker=(None, lock), # type: ignore
 			name="TestProducerNoTracker"
 		)
-		
+
 		producer._update_max_symbol_id(10)
-		
+
 		# Lock should never be acquired because of the early return
 		lock.__enter__.assert_not_called()
-  
+
 
 	def test_early_return_if_lock_is_none(self, mock_tracker, mock_queues):
 		val_proxy, _ = mock_tracker
 		val_proxy.value = 5
-		
+
 		producer = CipherProducer(
 			queues=mock_queues,
 			tracker=(val_proxy, None), # type: ignore
 			name="TestProducerNoLock"
 		)
-		
+
 		producer._update_max_symbol_id(10)
-		
+
 		# Value should remain unchanged because of the early return
 		assert val_proxy.value == 5
 

--- a/test/drive/test_cipher_producer.py
+++ b/test/drive/test_cipher_producer.py
@@ -13,6 +13,7 @@ class MockCipher(SubstitutionCipher):
 	def __init__(self, *args, **kwargs):
 		self.plaintext = "a" * 500
 		self.difficulty = 10
+		self.num_symbols = 3
 
 	def generate_key(self):
 		self.key = {"a": ["1"], "b": ["2"], "c": ["3"]}
@@ -20,7 +21,7 @@ class MockCipher(SubstitutionCipher):
 
 	def encipher(self):
 		self.ciphertext = "1 2 3"
-		self.recurrence_encoding = "1 2 3"
+		self.num_symbols = 3
 		return self.ciphertext
 
 
@@ -38,9 +39,22 @@ def mock_cipher_data():
 	mock_bytes = mock_json.encode("utf-8")
 	return mock_json, mock_bytes
 
+@pytest.fixture
+def mock_tracker(mocker):
+	"""Provides a mock tracker object for CipherProducer."""
+	tracker = mocker.Mock()
+	tracker.value = 0
+	tracker.lock = mocker.MagicMock()
+	return tracker, tracker.lock
+
+@pytest.fixture
+def mock_producer(mock_queues, mock_tracker):
+	"""Provides a mock CipherProducer object for testing."""
+	return CipherProducer(mock_queues, mock_tracker, name="TestProducer")
+
 
 class TestCipherProducerRun:
-	def test_successful_run(self, mocker, mock_queues, mock_cipher_data):
+	def test_successful_run(self, mocker, mock_queues, mock_cipher_data, mock_tracker):
 		input_q, output_q = mock_queues
 
 		sample_item = {
@@ -66,8 +80,8 @@ class TestCipherProducerRun:
 		)
 
 		producer = CipherProducer(
-			input_queue=input_q,
-			output_queue=output_q,
+			queues=(input_q, output_q),
+			tracker=mock_tracker,
 			name="TestProducer"
 		)
 
@@ -92,13 +106,13 @@ class TestCipherProducerRun:
 		assert "123" in last_filename
 		assert last_bytes == mock_cipher_data[1]
 
-	def test_stop_signal(self, mock_queues, caplog):
+	def test_stop_signal(self, mock_queues, mock_tracker, caplog):
 		input_q, output_q = mock_queues
 		input_q.put("STOP")
 
 		producer = CipherProducer(
-			input_queue=input_q,
-			output_queue=output_q,
+			queues=(input_q, output_q),
+			tracker=mock_tracker,
 			name="TestProducer"
 		)
 
@@ -106,7 +120,7 @@ class TestCipherProducerRun:
 
 		assert output_q.empty()
 
-	def test_generation_runtime_failure(self, mocker, mock_queues, caplog):
+	def test_generation_runtime_failure(self, mocker, mock_queues, mock_tracker, caplog):
 		input_q, output_q = mock_queues
 
 		input_q.put(("val", {"text": "fail", "source_id": "1"}))
@@ -121,8 +135,8 @@ class TestCipherProducerRun:
 		)
 
 		producer = CipherProducer(
-			input_queue=input_q,
-			output_queue=output_q,
+			queues=(input_q, output_q),
+			tracker=mock_tracker,
 			name="TestProducer"
 		)
 
@@ -131,15 +145,15 @@ class TestCipherProducerRun:
 		assert output_q.empty()
 		mock_log.info.assert_any_call("TestProducer finished generation.")
 
-	def test_run_handles_queue_empty_and_retries(self, mocker):
+	def test_run_handles_queue_empty_and_retries(self, mocker, mock_tracker):
 		mock_input_q = mocker.Mock()
 		mock_output_q = mocker.Mock()
 
 		mock_input_q.get.side_effect = [queue.Empty, "STOP"]
 
 		producer = CipherProducer(
-			input_queue=mock_input_q,
-			output_queue=mock_output_q,
+			queues=(mock_input_q, mock_output_q),
+			tracker=mock_tracker,
 			name="TestProducer"
 		)
 
@@ -147,7 +161,7 @@ class TestCipherProducerRun:
 
 		assert mock_input_q.get.call_count == 2
 
-	def test_run_handles_unexpected_loop_exception(self, mocker):
+	def test_run_handles_unexpected_loop_exception(self, mocker, mock_tracker):
 		mock_input_q = mocker.Mock()
 		mock_output_q = mocker.Mock()
 		mock_log = mocker.patch("drive.cipher_producer.log")
@@ -155,8 +169,8 @@ class TestCipherProducerRun:
 		mock_input_q.get.side_effect = [Exception("Queue connection lost"), "STOP"]
 
 		producer = CipherProducer(
-			input_queue=mock_input_q,
-			output_queue=mock_output_q,
+			queues=(mock_input_q, mock_output_q),
+			tracker=mock_tracker,
 			name="TestProducer"
 		)
 
@@ -165,11 +179,81 @@ class TestCipherProducerRun:
 		mock_log.error.assert_called()
 		assert "Queue connection lost" in mock_log.error.call_args[0][0]
 		assert mock_input_q.get.call_count == 2
+  
+  
+class TestUpdateMaxSymbolId:
+	def test_update_when_new_id_is_greater(self, mock_tracker, mock_queues):
+		val_proxy, lock = mock_tracker
+		val_proxy.value = 5  # Initial state
+		
+		producer = CipherProducer(
+			queues=mock_queues,
+			tracker=mock_tracker,
+			name="TestProducer"
+		)
+		
+		producer._update_max_symbol_id(10)
+		
+		# The value should be updated to 10
+		assert val_proxy.value == 10
+		# Verify the lock was actually acquired
+		lock.__enter__.assert_called_once()
+
+	def test_ignore_when_new_id_is_lesser_or_equal(self, mock_tracker, mock_queues):
+		val_proxy, lock = mock_tracker
+		val_proxy.value = 20  # Initial state is high
+		
+		producer = CipherProducer(
+			queues=mock_queues,
+			tracker=mock_tracker,
+			name="TestProducer"
+		)
+		
+		# Try a lesser value
+		producer._update_max_symbol_id(10)
+		assert val_proxy.value == 20
+		
+		# Try an equal value
+		producer._update_max_symbol_id(20)
+		assert val_proxy.value == 20
+		
+		# Lock should still be acquired both times to check the value safely
+		assert lock.__enter__.call_count == 2
+
+	def test_early_return_if_tracker_or_lock_is_none(self, mock_queues, mock_tracker):
+		_, lock = mock_tracker
+		
+		producer = CipherProducer(
+			queues=mock_queues,
+			tracker=(None, lock), # type: ignore
+			name="TestProducerNoTracker"
+		)
+		
+		producer._update_max_symbol_id(10)
+		
+		# Lock should never be acquired because of the early return
+		lock.__enter__.assert_not_called()
+  
+
+	def test_early_return_if_lock_is_none(self, mock_tracker, mock_queues):
+		val_proxy, _ = mock_tracker
+		val_proxy.value = 5
+		
+		producer = CipherProducer(
+			queues=mock_queues,
+			tracker=(val_proxy, None), # type: ignore
+			name="TestProducerNoLock"
+		)
+		
+		producer._update_max_symbol_id(10)
+		
+		# Value should remain unchanged because of the early return
+		assert val_proxy.value == 5
 
 
 class TestGenerateCipherLogic:
-	def test_generate_cipher_success(self, mocker):
-		producer = CipherProducer(mocker.Mock(), mocker.Mock(), name="Test")
+	def test_generate_cipher_success(self, mocker, mock_producer):
+		producer = mock_producer
 
 		sample_item: TextStream = {
 			"text": "testslice",
@@ -188,14 +272,13 @@ class TestGenerateCipherLogic:
 
 		mocked_homophonic_cipher.assert_called_once_with(sample_item)
 
-		mock_cipher_instance.generate_difficulty.assert_called_once()
 		mock_cipher_instance.generate_key.assert_called_once()
 		mock_cipher_instance.encipher.assert_called_once()
 
 		assert cipher == mock_cipher_instance
 
-	def test_generate_cipher_errors(self, mocker, caplog):
-		producer = CipherProducer(mocker.Mock(), mocker.Mock(), name="Test")
+	def test_generate_cipher_errors(self, mocker, mock_producer, caplog):
+		producer = mock_producer
 
 		sample_item: TextStream = {
 			"text": "invalid",
@@ -217,8 +300,8 @@ class TestGenerateCipherLogic:
 		mock_log.error.assert_called()
 		assert "Error generating cipher" in mock_log.error.call_args[0][0]
 
-	def test_generate_cipher_unexpected_exception(self, mocker):
-		producer = CipherProducer(mocker.Mock(), mocker.Mock(), name="Test")
+	def test_generate_cipher_unexpected_exception(self, mocker, mock_producer):
+		producer = mock_producer
 		sample_item: TextStream = {
 			"text": "crash_test",
 			"source_id": "123",

--- a/test/drive/test_drive_uploader.py
+++ b/test/drive/test_drive_uploader.py
@@ -1,24 +1,28 @@
 import pytest
 import multiprocessing as mp
 import io
-from typing import Final
+import queue
+from typing import Final, Any
 from dataclasses import dataclass
 from multiprocessing.queues import Queue as MPQueue
-from typing import Any
-from drive.drive_uploader import DriveUploader, DriveUploaderConfig, BatchState
-import queue
 
+from drive.drive_uploader import DriveUploader, DriveUploaderConfig, BatchState
+
+# --- Constants & Test Data ---
 BATCH_SIZE: Final[int] = 2
 MOCK_SPLIT_FOLDERS: Final[dict[str, str]] = {
 	"train": "mock_train_123",
 	"val": "mock_val_123",
+	"metadata": "mock_metadata_123",
 }
 SENTINEL: Final[str] = "STOP"
 
+
+# --- Shared Fixtures ---
 @pytest.fixture(autouse=True)
 def silent_zipfile(mocker):
-    """Prevents any real ZipFile from being opened during tests."""
-    return mocker.patch("zipfile.ZipFile")
+	"""Prevents any real ZipFile from being opened during tests."""
+	return mocker.patch("zipfile.ZipFile")
 
 
 @pytest.fixture
@@ -34,7 +38,6 @@ def uploader_config():
 
 @pytest.fixture
 def mock_cipher_item():
-	# Now a 3-tuple including the split
 	return ("train", "cipher_123_10.json", b"mock_cipher_data_1")
 
 
@@ -62,29 +65,33 @@ def ctx(mock_queue, uploader_config, mock_cipher_item, mock_cipher_item_2):
 	)
 
 
-class TestDriveUploader:
+# --- Test Classes ---
+
+
+class TestDriveUploaderInitialization:
+	"""Tests covering object initialization and dataclasses."""
+
 	def test_initialization(self, mock_queue, uploader_config):
 		uploader = DriveUploader(mock_queue, uploader_config, name="Test")
 		assert uploader.split_folders == MOCK_SPLIT_FOLDERS
 		assert uploader.total_ciphers == 10
 		assert uploader.uploaded_count == 0
-		# Ensure batch states are created for all splits
-		assert "train" in uploader.batch_states
-		assert "val" in uploader.batch_states
 
 	def test_batch_state_init(self):
-		# Now requires the split argument
 		bs = BatchState(split="val", batch_num=5)
 		assert bs.split == "val"
 		assert bs.current_batch_count == 0
 		assert bs.batch_num == 5
 		assert isinstance(bs.batch_buffer, io.BytesIO)
 
+
+class TestDriveUploaderRunLoop:
+	"""Tests covering the main execution loop, queue pulling, and routing."""
+
 	def test_successful_full_upload(
 		self, mocker, mock_queue, mock_cipher_item, mock_cipher_item_2
 	):
 		total_to_upload = 2
-
 		local_config = DriveUploaderConfig(
 			split_folders=MOCK_SPLIT_FOLDERS, total_ciphers=total_to_upload
 		)
@@ -111,19 +118,15 @@ class TestDriveUploader:
 		mock_queue.put(SENTINEL)
 
 		uploader = DriveUploader(mock_queue, local_config, name="TestUploader")
-
 		uploader.run()
 
 		assert uploader.uploaded_count == total_to_upload
 		assert mock_upload_drive.call_count == 1
 		mock_pbar.update.assert_called_once_with(BATCH_SIZE)
 
-		assert mock_upload_drive.call_count == 1
-
 	def test_empty_queue(self, mocker, uploader_config):
 		"""Test that the uploader handles empty queues gracefully via timeouts."""
 		queue_mock = mocker.Mock()
-
 		queue_mock.get.side_effect = [queue.Empty, SENTINEL]
 
 		mocker.patch(
@@ -132,26 +135,69 @@ class TestDriveUploader:
 		)
 
 		uploader = DriveUploader(queue_mock, uploader_config, name="Test")
-
 		uploader.run()
 
 		assert uploader.uploaded_count == 0
 		assert queue_mock.get.call_count == 2
 
+		# Second run
 		uploader.uploaded_count = 10
-
-		queue_mock.get.side_effect = [queue.Empty]
-
+		queue_mock.get.side_effect = [queue.Empty, SENTINEL]
 		uploader.run()
 
 		assert uploader.uploaded_count == 10
-		assert queue_mock.get.call_count == 2
+		assert queue_mock.get.call_count == 4
 
-	def test_upload_failure(
-		self,
-		mocker,
-		ctx: UploaderTestContext,
+	def test_authentication_failure(
+		self, mocker, mock_queue, uploader_config, mock_cipher_item
 	):
+		mocker.patch(
+			"drive.drive_uploader.authenticate_drive_terminal",
+			side_effect=Exception("Auth failed"),
+		)
+		mock_log = mocker.patch("drive.drive_uploader.log")
+
+		mock_queue.put(mock_cipher_item)
+		mock_queue.put(SENTINEL)
+
+		uploader = DriveUploader(mock_queue, uploader_config, name="TestUploader")
+		uploader.run()
+
+		mock_log.critical.assert_called_once_with(
+			"TestUploader: Error authenticating drive service: Auth failed",
+			exc_info=True,
+		)
+		assert uploader.uploaded_count == 0
+
+	def test_metadata_routing_in_run(self, mocker, mock_queue, uploader_config):
+		"""Test that the 'metadata' split is routed correctly and not batched."""
+		mocker.patch(
+			"drive.drive_uploader.authenticate_drive_terminal",
+			return_value=mocker.Mock(),
+		)
+		mock_upload_raw = mocker.patch.object(DriveUploader, "_upload_raw_file")
+
+		mock_queue.put(
+			("metadata", "metadata_vocab_size.json", b'{"max_symbol_id": 100}')
+		)
+		mock_queue.put(SENTINEL)
+
+		uploader = DriveUploader(mock_queue, uploader_config, name="TestUploader")
+		mocker.patch("drive.drive_uploader.tqdm")
+
+		uploader.run()
+
+		assert "metadata" not in uploader.batch_states
+		assert "train" in uploader.batch_states
+		mock_upload_raw.assert_called_once_with(
+			"metadata", "metadata_vocab_size.json", b'{"max_symbol_id": 100}'
+		)
+
+
+class TestDriveUploaderBatchHelpers:
+	"""Tests covering the zipped batch logic and API interactions."""
+
+	def test_upload_failure(self, mocker, ctx: UploaderTestContext):
 		mocker.patch(
 			"drive.drive_uploader.authenticate_drive_terminal",
 			return_value=mocker.Mock(),
@@ -163,23 +209,16 @@ class TestDriveUploader:
 		ctx.queue.put(SENTINEL)
 
 		uploader = DriveUploader(ctx.queue, ctx.config, name="TestUploader")
-
 		uploader.run()
 
 		assert uploader.uploaded_count == 0
-		# Updated assertion to match the new string format with split
 		mock_log.critical.assert_called_once_with(
 			"FATAL: train Batch 1 failed all retries."
 		)
 
-	def test_partial_final_batch(
-		self,
-		mocker,
-		ctx: UploaderTestContext,
-	):
+	def test_partial_final_batch(self, mocker, ctx: UploaderTestContext):
 		total_expected = 3
 		ctx.config.total_ciphers = total_expected
-
 		mocker.patch("drive.drive_uploader.BATCH_SIZE", 2)
 
 		mocker.patch(
@@ -204,12 +243,10 @@ class TestDriveUploader:
 		ctx.queue.put(SENTINEL)
 
 		uploader = DriveUploader(ctx.queue, ctx.config, name="TestUploader")
-
 		uploader.run()
 
 		assert uploader.uploaded_count == total_expected
 		assert mock_upload_drive.call_count == 2
-		# Assert filenames are prefixed with the split
 		mock_upload_drive.assert_any_call(
 			mocker.ANY, mocker.ANY, "train_ciphers_batch_1.zip", mocker.ANY
 		)
@@ -218,29 +255,6 @@ class TestDriveUploader:
 		)
 		mock_pbar.update.assert_any_call(2)
 		mock_pbar.update.assert_any_call(1)
-
-	def test_authentication_failure(
-		self, mocker, mock_queue, uploader_config, mock_cipher_item
-	):
-		mocker.patch(
-			"drive.drive_uploader.authenticate_drive_terminal",
-			side_effect=Exception("Auth failed"),
-		)
-
-		mock_log = mocker.patch("drive.drive_uploader.log")
-
-		mock_queue.put(mock_cipher_item)
-		mock_queue.put(SENTINEL)
-
-		uploader = DriveUploader(mock_queue, uploader_config, name="TestUploader")
-
-		uploader.run()
-
-		mock_log.critical.assert_called_once_with(
-			"TestUploader: Error authenticating drive service: Auth failed",
-			exc_info=True,
-		)
-		assert uploader.uploaded_count == 0
 
 	def test_upload_batch_helper_success(self, mocker, uploader_config):
 		uploader = DriveUploader(mocker.Mock(), uploader_config, name="TestUploader")
@@ -251,11 +265,9 @@ class TestDriveUploader:
 		)
 		mock_pbar = mocker.Mock()
 
-		# Added split parameter
 		bs_initial = BatchState(split="train", batch_num=3)
 		bs_initial.current_batch_count = 5
 		bs_initial.batch_buffer.write(b"some_zip_data")
-
 		bs_initial.batch_buffer.seek(0)
 
 		new_bs = uploader._upload_batch(bs_initial, mock_pbar, "test_batch.zip")
@@ -263,12 +275,11 @@ class TestDriveUploader:
 		assert new_bs.split == "train"
 		assert new_bs.batch_num == 4
 		assert new_bs.current_batch_count == 0
-
 		assert mock_upload.call_count == 1
 		mock_pbar.update.assert_called_once_with(5)
 		new_bs.zip_buffer.close()
 
-	def test_upload_batch_helper_failure(self, mocker, uploader_config, caplog):
+	def test_upload_batch_helper_failure(self, mocker, uploader_config):
 		uploader = DriveUploader(mocker.Mock(), uploader_config, name="TestUploader")
 		uploader.drive_service = mocker.Mock()
 		mock_log = mocker.patch("drive.drive_uploader.log")
@@ -285,8 +296,6 @@ class TestDriveUploader:
 
 		assert new_bs.batch_num == 6
 		assert new_bs.current_batch_count == 0
-
-		# Updated error string
 		mock_log.critical.assert_called_once_with(
 			"FATAL: train Batch 5 failed all retries."
 		)
@@ -295,10 +304,7 @@ class TestDriveUploader:
 		new_bs.zip_buffer.close()
 
 	def test_upload_batch_exception_handling(self, mocker, uploader_config):
-		"""Test the exception block in _upload_batch."""
 		mock_bs_class = mocker.patch("drive.drive_uploader.BatchState")
-
-		# Setup the return value for the NEW BatchState created inside _upload_batch
 		mock_new_bs = mocker.Mock()
 		mock_new_bs.batch_num = 8
 		mock_new_bs.current_batch_count = 0
@@ -310,11 +316,10 @@ class TestDriveUploader:
 
 		mocker.patch(
 			"drive.drive_uploader.upload_to_drive",
-			side_effect=Exception("Unexpected API Crash")
+			side_effect=Exception("Unexpected API Crash"),
 		)
 		mock_pbar = mocker.Mock()
 
-		# This now uses the patched ZipFile
 		bs_initial = BatchState(split="train", batch_num=7)
 		bs_initial.current_batch_count = 5
 
@@ -322,10 +327,71 @@ class TestDriveUploader:
 
 		assert new_bs.batch_num == 8
 		assert new_bs.current_batch_count == 0
-
 		mock_log.error.assert_called_once_with(
 			"FATAL: Unexpected error uploading train Batch 7: Unexpected API Crash",
 			exc_info=True,
 		)
-
 		mock_pbar.update.assert_not_called()
+
+
+class TestDriveUploaderRawFileHelpers:
+	"""Tests covering the raw file upload logic specifically for metadata."""
+
+	def test_upload_raw_file_success(self, mocker, uploader_config):
+		uploader = DriveUploader(mocker.Mock(), uploader_config, name="TestUploader")
+		uploader.drive_service = mocker.Mock()
+		mock_log = mocker.patch("drive.drive_uploader.log")
+
+		mock_upload = mocker.patch(
+			"drive.drive_uploader.upload_to_drive", return_value="raw_file_id_1"
+		)
+
+		uploader._upload_raw_file("metadata", "meta.json", b"raw_data")
+
+		mock_upload.assert_called_once_with(
+			uploader.drive_service, b"raw_data", "meta.json", "mock_metadata_123"
+		)
+		mock_log.info.assert_called_once_with(
+			"Uploaded raw file meta.json to metadata folder: raw_file_id_1"
+		)
+
+	def test_upload_raw_file_missing_folder(self, mocker, uploader_config):
+		uploader = DriveUploader(mocker.Mock(), uploader_config, name="TestUploader")
+		mock_log = mocker.patch("drive.drive_uploader.log")
+		mock_upload = mocker.patch("drive.drive_uploader.upload_to_drive")
+
+		uploader._upload_raw_file("unknown_split", "meta.json", b"raw_data")
+
+		mock_upload.assert_not_called()
+		mock_log.error.assert_called_once_with(
+			"Cannot upload meta.json: No folder ID found for split 'unknown_split'"
+		)
+
+	def test_upload_raw_file_api_rejection(self, mocker, uploader_config):
+		uploader = DriveUploader(mocker.Mock(), uploader_config, name="TestUploader")
+		uploader.drive_service = mocker.Mock()
+		mock_log = mocker.patch("drive.drive_uploader.log")
+
+		mocker.patch("drive.drive_uploader.upload_to_drive", return_value=None)
+		uploader._upload_raw_file("metadata", "meta.json", b"raw_data")
+
+		mock_log.error.assert_called_once_with(
+			"FATAL: Failed to upload raw file meta.json to metadata."
+		)
+
+	def test_upload_raw_file_exception_handling(self, mocker, uploader_config):
+		uploader = DriveUploader(mocker.Mock(), uploader_config, name="TestUploader")
+		uploader.drive_service = mocker.Mock()
+		mock_log = mocker.patch("drive.drive_uploader.log")
+
+		mocker.patch(
+			"drive.drive_uploader.upload_to_drive",
+			side_effect=Exception("Network Timeout"),
+		)
+
+		uploader._upload_raw_file("metadata", "meta.json", b"raw_data")
+
+		mock_log.error.assert_called_once_with(
+			"FATAL: Unexpected error uploading raw file meta.json: Network Timeout",
+			exc_info=True,
+		)

--- a/test/drive/test_upload_manager.py
+++ b/test/drive/test_upload_manager.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import call, MagicMock
 from drive.cipher_manager import CipherManager
+import json
 
 
 @pytest.fixture
@@ -13,6 +14,10 @@ def base_config():
 		"val": {
 			"count": 30,
 			"folder_id": "val_folder"
+		},
+		"metadata": {
+			"folder_id": "metadata_folder",
+			"count": 0
 		}
 	}
 
@@ -26,6 +31,10 @@ class TestCipherManager:
 
 		mock_job_queue = MagicMock(name="job_queue")
 		mock_result_queue = MagicMock(name="result_queue")
+
+		mock_value_proxy = MagicMock(name="max_symbol_id")
+		mock_value_proxy.value = 0
+		mock_manager_inst.Value.return_value = mock_value_proxy
 
 		mock_manager_inst.Queue.side_effect = [mock_job_queue, mock_result_queue]
 
@@ -42,7 +51,7 @@ class TestCipherManager:
 			text_stream_source=dummy_stream
 		)
 
-		assert manager.split_folders == {"train": "train_folder", "val": "val_folder"}
+		assert manager.split_folders == {"train": "train_folder", "val": "val_folder", "metadata": "metadata_folder"}
 		assert manager.total_count == 100
 		assert manager.num_workers == 4
 
@@ -95,7 +104,10 @@ class TestCipherManager:
 
 		assert mock_producer.join.call_count == 2
 
-		mock_result_q.put.assert_called_once_with("STOP")
+		assert mock_result_q.put.call_count == 2
+
+		mock_result_q.put.assert_has_calls([call(("metadata", "metadata.json", b'{"max_symbol_id": 0}')), call("STOP")], any_order=False)
+
 
 		mock_uploader.join.assert_called_once()
 
@@ -129,7 +141,7 @@ class TestCipherManager:
 		# Create a stream of 1001 items to trigger the log at 1000
 		mock_stream = [("train", {"text": "A"}) for _ in range(1001)]
 
-		manager = CipherManager(base_config, mock_stream)
+		manager = CipherManager({"train": {"folder_id": "train_folder", "count": 1001}}, mock_stream)
 		# We can mock start/join to speed up the test
 		mocker.patch("drive.cipher_manager.DriveUploader.start")
 		mocker.patch("drive.cipher_manager.DriveUploader.join")
@@ -161,3 +173,56 @@ class TestCipherManager:
 		mock_log.warning.assert_called_with("Job interrupted! Stopping...")
 		# Verify cleanup (Sentinels) still happened in finally block
 		assert mock_job_q.put.called
+
+class TestCipherManagerPeakUpload:
+	def test_manager_queues_peak_value_metadata(self, mocker):
+		"""Verifies the max_symbol_id is formatted and queued before the sentinel."""
+
+		# 1. Mock the heavy multiprocessing classes so they don't actually run
+		mocker.patch("drive.cipher_manager.DriveUploader")
+		mocker.patch("drive.cipher_manager.CipherProducer")
+
+		# 2. Setup a dummy configuration and tiny stream
+		dummy_config = {
+			"train": {"folder_id": "dummy_folder_abc", "count": 1}
+		}
+		dummy_stream = [
+			("train", {"text": "hello", "source_id": "1", "source_name": "x", "length": 5})
+		]
+
+		# 3. Initialize the Manager
+		manager = CipherManager(
+			config=dummy_config,
+			text_stream_source=dummy_stream,
+			num_workers=1
+		)
+
+		# 4. Simulate the workers finding a high homophone count
+		expected_peak = 2501
+		manager.max_symbol_id.value = expected_peak
+
+		# 5. Execute (Since workers are mocked, this will just process queues instantly)
+		manager.execute()
+
+		# 6. Drain the result queue to inspect what the manager tried to send to the uploader
+		queued_items = []
+		while not manager.result_queue.empty():
+			queued_items.append(manager.result_queue.get())
+
+		# --- ASSERTIONS ---
+
+		# The very last item MUST be the STOP sentinel
+		assert queued_items[-1] == CipherManager.SENTINEL
+
+		# The item immediately preceding the sentinel MUST be the metadata file
+		metadata_task = queued_items[-2]
+
+		# Unpack the tuple: (split, filename, file_bytes)
+		split_name, filename, file_bytes = metadata_task
+
+		assert split_name == "metadata"
+		assert filename == "metadata.json"
+
+		# Decode the bytes back to a dictionary and verify the value
+		payload = json.loads(file_bytes.decode("utf-8"))
+		assert payload["max_symbol_id"] == expected_peak

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -285,15 +285,15 @@ class TestHomophonicCipher:
 			assert cipher.key["a"] == [1]
 			assert cipher.key["b"] == [2]
 			assert 77 not in cipher.key["a"]
-   
+
 	class TestRemappingIntegrity:
 		def test_first_seen_is_always_one(self, sample_stream_short):
 			"""
-			Tests that the actual value of the original symbol doesn't matter; 
+			Tests that the actual value of the original symbol doesn't matter;
 			the first one encountered in the stream MUST become '1'.
 			"""
 			cipher = HomophonicCipher(sample_stream_short)
-			
+
 			# Scenario A: 'z' is 500, 'a' is 10. Text starts with 'z'.
 			cipher.key = {"z": [500], "a": [10]}
 			cipher.ciphertext = "500 10 500"
@@ -312,16 +312,16 @@ class TestHomophonicCipher:
 
 		def test_key_value_consistency(self, sample_stream_short):
 			"""
-			Verify that if a letter has multiple homophones, the remapping 
+			Verify that if a letter has multiple homophones, the remapping
 			correctly updates all of them within the key list.
 			"""
 			cipher = HomophonicCipher(sample_stream_short)
 			# 'e' has three homophones. We use them in a specific order.
 			cipher.key = {"e": [100, 200, 300]}
 			cipher.ciphertext = "300 100 200"
-			
+
 			cipher._apply_recurrence_and_remap_key()
-			
+
 			# Appearance: 300->1, 100->2, 200->3
 			assert cipher.ciphertext == "1 2 3"
 			# The list in the key should now reflect these new values
@@ -337,9 +337,9 @@ class TestHomophonicCipher:
 			cipher.key = {"a": [1], "b": [2], "c": [3]}
 			# Ciphertext where they appear in reverse order
 			cipher.ciphertext = "3 2 1"
-			
+
 			cipher._apply_recurrence_and_remap_key()
-			
+
 			# If mapping is done correctly: 3->1, 2->2, 1->3
 			assert cipher.ciphertext == "1 2 3"
 			assert cipher.key["c"] == [1]
@@ -348,15 +348,15 @@ class TestHomophonicCipher:
 
 		def test_key_remains_int_types(self, sample_stream_short):
 			"""
-			Ensure the remapped key contains integers (for JSON) 
+			Ensure the remapped key contains integers (for JSON)
 			while the ciphertext remains a string of numbers.
 			"""
 			cipher = HomophonicCipher(sample_stream_short)
 			cipher.key = {"a": [123]}
 			cipher.ciphertext = "123"
-			
+
 			cipher._apply_recurrence_and_remap_key()
-			
+
 			assert isinstance(cipher.key["a"][0], int)
 			assert isinstance(cipher.ciphertext.split()[0], str)
 

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -65,138 +65,165 @@ def sample_stream_illegal(sample_texts_illegal):
 		for text in sample_texts_illegal
 	]
 
+
+@pytest.fixture
+def bad_streams():
+	"""Returns a list of invalid TextStream dictionaries for HomophonicCipher."""
+	return [
+		{
+			"text": "",
+			"source_id": "book_123",
+			"source_name": "Test Book",
+			"length": len("invalid"),
+		},
+		{
+			"text": " ",
+			"source_id": "book_123",
+			"source_name": "Test Book",
+			"length": 0,
+		},
+		{
+			"text": "inval id",
+			"source_id": "book_123",
+			"source_name": "Test Book",
+			"length": None,
+		},
+	]
+
+
 # --- HomophonicCipher Tests ---
 
 
 class TestHomophonicCipher:
-	def test_legal_plaintext(self, sample_stream_legal):
-		# Pass the stream object (dict), not just the string
-		cipher = HomophonicCipher(sample_stream_legal)
-		cipher.generate_key()
-		cipher.encipher()
+	class TestHomophonicCipherInit:
+		def test_legal_plaintext(self, sample_stream_legal):
+			# Pass the stream object (dict), not just the string
+			cipher = HomophonicCipher(sample_stream_legal)
+			cipher.generate_key()
+			cipher.encipher()
 
-		assert cipher.plaintext == sample_stream_legal["text"]
-		assert cipher.source_id == sample_stream_legal["source_id"]
-		assert cipher.source_name == sample_stream_legal["source_name"]
+			assert cipher.plaintext == sample_stream_legal["text"]
+			assert cipher.source_id == sample_stream_legal["source_id"]
+			assert cipher.source_name == sample_stream_legal["source_name"]
 
-		assert MIN_DIFFICULTY <= cipher.difficulty <= MAX_DIFFICULTY
-		assert isinstance(cipher.key, dict)
-		assert all(isinstance(v, list) for v in cipher.key.values())
-		assert isinstance(cipher.ciphertext, str)
-		assert all(num.isdigit() for num in cipher.ciphertext.split())
+			assert MIN_DIFFICULTY <= cipher.difficulty <= MAX_DIFFICULTY
+			assert isinstance(cipher.key, dict)
+			assert all(isinstance(v, list) for v in cipher.key.values())
+			assert isinstance(cipher.ciphertext, str)
+			assert all(num.isdigit() for num in cipher.ciphertext.split())
 
-	def test_all_homophones_used(self, sample_stream_legal):
-		cipher = HomophonicCipher(sample_stream_legal)
-		used_homophones = set(int(num) for num in cipher.ciphertext.split())
-		all_homophones = set()
-		for homophones in cipher.key.values():
-			all_homophones.update(homophones)
-		assert used_homophones == all_homophones, (
-			f"Used homophones {used_homophones} do not match all homophones {all_homophones}"
-		)
-
-	def test_illegal_plaintext(self, sample_texts_illegal):
-		for text in sample_texts_illegal:
-			# Wrap illegal text in a TextStream dict structure
-			bad_stream = {"text": text, "source_name": "bad"}
-
-			with pytest.raises(KeyError) as excinfo:
-				HomophonicCipher(bad_stream)  # type: ignore
-			assert "text_obj" in str(excinfo.value)
-			assert "Missing keys:" in str(excinfo.value)
-			assert "source_id" in str(excinfo.value)
-			assert "source_name" in str(excinfo.value)
-
-	def test_defined_difficulty(self, sample_stream_legal):
-		for difficulty in range(4, 11):
-			cipher = HomophonicCipher(sample_stream_legal, difficulty=difficulty)
-			assert cipher.difficulty == difficulty
-
-	def test_key_homophones_count(self, sample_stream_legal):
-		cipher = HomophonicCipher(sample_stream_legal)
-		cipher.generate_key()
-		total_homophones = sum(len(v) for v in cipher.key.values())
-		expected_homophones = round(
-			len(sample_stream_legal["text"]) / cipher.difficulty
-		)
-
-		unique_letters = len(set(sample_stream_legal["text"]))
-
-		assert total_homophones >= unique_letters, (
-			f"Total homophones {total_homophones} is less than unique letters {unique_letters}"
-		)
-
-		expected_range = max(15, expected_homophones)
-		assert abs(total_homophones - expected_homophones) <= expected_range, (
-			f"Total homophones {total_homophones} not within acceptable range."
-		)
-
-	def test_ciphertext_numbers_within_range(self, sample_stream_legal):
-		cipher = HomophonicCipher(sample_stream_legal)
-		ciphertext_numbers = list(map(int, cipher.ciphertext.split()))
-		total_homophones = sum(len(v) for v in cipher.key.values())
-		assert all(1 <= num <= total_homophones for num in ciphertext_numbers)
-
-	def test_ciphertext_length(self, sample_stream_legal):
-		cipher = HomophonicCipher(sample_stream_legal)
-		cipher.generate_key()
-		cipher.encipher()
-		ciphertext_numbers = cipher.ciphertext.split()
-		assert len(ciphertext_numbers) == len(sample_stream_legal["text"])
-
-	def test_json_serialization(self, sample_stream_legal):
-		cipher = HomophonicCipher(sample_stream_legal)
-		json_data = cipher.__json__()
-		assert isinstance(json_data, dict)
-		assert json_data["plaintext"] == sample_stream_legal["text"]
-		assert json_data["source_id"] == sample_stream_legal["source_id"]
-		assert json_data["source_name"] == sample_stream_legal["source_name"]
-		assert json_data["difficulty"] == cipher.difficulty
-		assert json_data["key"] == cipher.key
-		assert json_data["ciphertext"] == cipher.ciphertext
-
-	def test_str_representation(self, sample_stream_legal):
-		cipher = HomophonicCipher(sample_stream_legal)
-		str_repr = str(cipher)
-		assert 'HomophonicCipher(Plaintext: "' in str_repr
-		assert f'"{sample_stream_legal["text"]}"' in str_repr
-		assert f"Difficulty: {cipher.difficulty}" in str_repr
-		assert f"Key: {cipher.key}" in str_repr
-		assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
-		assert f'Recurrence Encoding: "{cipher.recurrence_encoding}"' in str_repr  # type: ignore
-
-	def test_invalid_difficulty(self, sample_stream_legal):
-		for invalid_difficulty in [3, 31, -1, 0]:
-			with pytest.raises(ValueError) as excinfo:
-				HomophonicCipher(sample_stream_legal, difficulty=invalid_difficulty)
-			assert (
-				f"Parameter `difficulty` must be between {MIN_DIFFICULTY} and {MAX_DIFFICULTY}."
-				in str(excinfo.value)
+		def test_all_homophones_used(self, sample_stream_legal):
+			cipher = HomophonicCipher(sample_stream_legal)
+			used_homophones = set(int(num) for num in cipher.ciphertext.split())
+			all_homophones = set()
+			for homophones in cipher.key.values():
+				all_homophones.update(homophones)
+			assert used_homophones == all_homophones, (
+				f"Used homophones {used_homophones} do not match all homophones {all_homophones}"
 			)
 
-	def test_non_integer_difficulty(self, sample_stream_legal):
-		for non_integer in [5.5, "ten"]:
-			with pytest.raises(TypeError) as excinfo:
-				HomophonicCipher(sample_stream_legal, difficulty=non_integer)
-			assert "Parameter `difficulty` must be of type int, or None." in str(
-				excinfo.value
+		def test_illegal_plaintext(self, sample_texts_illegal):
+			for text in sample_texts_illegal:
+				# Wrap illegal text in a TextStream dict structure
+				bad_stream = {"text": text, "source_name": "bad"}
+
+				with pytest.raises(KeyError) as excinfo:
+					HomophonicCipher(bad_stream)  # type: ignore
+				assert "text_obj" in str(excinfo.value)
+				assert "Missing keys:" in str(excinfo.value)
+				assert "source_id" in str(excinfo.value)
+				assert "source_name" in str(excinfo.value)
+
+		def test_defined_difficulty(self, sample_stream_legal):
+			for difficulty in range(4, 11):
+				cipher = HomophonicCipher(sample_stream_legal, difficulty=difficulty)
+				assert cipher.difficulty == difficulty
+
+		def test_key_homophones_count(self, sample_stream_legal):
+			cipher = HomophonicCipher(sample_stream_legal)
+			cipher.generate_key()
+			total_homophones = sum(len(v) for v in cipher.key.values())
+			expected_homophones = round(
+				len(sample_stream_legal["text"]) / cipher.difficulty
 			)
 
-	def test_non_stream_plaintext(self):
-		# The validator expects text_obj to be the first arg, validation might fail
-		# inside __init__ when accessing ["text"] if input is not subscriptable
-		for invalid_input in [12345, None, 5.67]:
-			with pytest.raises(TypeError):
-				HomophonicCipher(invalid_input)
+			unique_letters = len(set(sample_stream_legal["text"]))
 
-	def test_empty_string_plaintext_in_stream(self):
-		bad_stream = {"text": " ", "source_id": "1", "source_name": "test", "length": 1}
-		with pytest.raises(ValueError) as excinfo:
-			HomophonicCipher(bad_stream)  # type: ignore
-		assert (
-			"must include a non-empty, lowercase alphabetic string with no spaces in the text field."
-			in str(excinfo.value)
-		)
+			assert total_homophones >= unique_letters, (
+				f"Total homophones {total_homophones} is less than unique letters {unique_letters}"
+			)
+
+			expected_range = max(15, expected_homophones)
+			assert abs(total_homophones - expected_homophones) <= expected_range, (
+				f"Total homophones {total_homophones} not within acceptable range."
+			)
+
+		def test_ciphertext_numbers_within_range(self, sample_stream_legal):
+			cipher = HomophonicCipher(sample_stream_legal)
+			ciphertext_numbers = list(map(int, cipher.ciphertext.split()))
+			total_homophones = sum(len(v) for v in cipher.key.values())
+			assert all(1 <= num <= total_homophones for num in ciphertext_numbers)
+
+		def test_ciphertext_length(self, sample_stream_legal):
+			cipher = HomophonicCipher(sample_stream_legal)
+			cipher.generate_key()
+			cipher.encipher()
+			ciphertext_numbers = cipher.ciphertext.split()
+			assert len(ciphertext_numbers) == len(sample_stream_legal["text"])
+
+		def test_invalid_difficulty(self, sample_stream_legal):
+			for invalid_difficulty in [3, 31, -1, 0]:
+				with pytest.raises(ValueError) as excinfo:
+					HomophonicCipher(sample_stream_legal, difficulty=invalid_difficulty)
+				assert (
+					f"Parameter `difficulty` must be between {MIN_DIFFICULTY} and {MAX_DIFFICULTY}."
+					in str(excinfo.value)
+				)
+
+		def test_non_integer_difficulty(self, sample_stream_legal):
+			for non_integer in [5.5, "ten"]:
+				with pytest.raises(TypeError) as excinfo:
+					HomophonicCipher(sample_stream_legal, difficulty=non_integer)
+				assert "Parameter `difficulty` must be of type int, or None." in str(
+					excinfo.value
+				)
+
+		def test_non_stream_plaintext(self):
+			# The validator expects text_obj to be the first arg, validation might fail
+			# inside __init__ when accessing ["text"] if input is not subscriptable
+			for invalid_input in [12345, None, 5.67]:
+				with pytest.raises(TypeError):
+					HomophonicCipher(invalid_input)
+
+		def test_empty_string_plaintext_in_stream(self, bad_streams):
+			for bad_stream in bad_streams:
+				with pytest.raises(ValueError) as excinfo:
+					HomophonicCipher(bad_stream)  # type: ignore
+				assert (
+					"must include a non-empty, lowercase alphabetic string with no spaces in the text field."
+					in str(excinfo.value)
+				)
+
+	class TestHomophonicSerialization:
+		def test_json_serialization(self, sample_stream_legal):
+			cipher = HomophonicCipher(sample_stream_legal)
+			json_data = cipher.__json__()
+			assert isinstance(json_data, dict)
+			assert json_data["plaintext"] == sample_stream_legal["text"]
+			assert json_data["source_id"] == sample_stream_legal["source_id"]
+			assert json_data["source_name"] == sample_stream_legal["source_name"]
+			assert json_data["difficulty"] == cipher.difficulty
+			assert json_data["key"] == cipher.key
+			assert json_data["ciphertext"] == cipher.ciphertext
+
+		def test_str_representation(self, sample_stream_legal):
+			cipher = HomophonicCipher(sample_stream_legal)
+			str_repr = str(cipher)
+			assert 'HomophonicCipher(Plaintext: "' in str_repr
+			assert f'"{sample_stream_legal["text"]}"' in str_repr
+			assert f"Difficulty: {cipher.difficulty}" in str_repr
+			assert f"Key: {cipher.key}" in str_repr
+			assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
 
 	def test_recurrence_encoding(self, sample_stream_legal):
 		cipher = HomophonicCipher(sample_stream_legal)
@@ -210,108 +237,216 @@ class TestHomophonicCipher:
 		assert all(num >= 1 for num in encoding_numbers)
 		assert set(encoding_numbers) == set(range(1, max(encoding_numbers) + 1))
 
+	class TestApplyRecurrenceAndRemapKey:
+		def test_standard_remapping_logic(self, sample_stream_short):
+			"""Verify that arbitrary cipher symbols are remapped to 1..N order."""
+			cipher = HomophonicCipher(sample_stream_short)
+			# Manually inject state to test the remapping logic in isolation
+			# Plaintext: abc... (from sample_stream_short)
+			# Let's simulate a ciphertext where 'a'=99, 'b'=10, 'c'=50
+			cipher.key = {"a": [99], "b": [10], "c": [50]}
+			cipher.ciphertext = "99 10 50 10 50"  # Represents "abcbc"
+
+			cipher._apply_recurrence_and_remap_key()
+
+			# 1. Ciphertext should now be 1 2 3 2 3
+			assert cipher.ciphertext == "1 2 3 2 3"
+
+			# 2. Key must match the new values
+			assert cipher.key["a"] == [1]
+			assert cipher.key["b"] == [2]
+			assert cipher.key["c"] == [3]
+
+		def test_homophone_remapping(self, sample_stream_short):
+			"""Ensure multiple homophones for one letter are mapped to distinct IDs."""
+			cipher = HomophonicCipher(sample_stream_short)
+			# 'a' has two homophones, 'b' has one
+			cipher.key = {"a": [88, 89], "b": [44]}
+			# Sequence: a(89) a(88) b(44)
+			cipher.ciphertext = "89 88 44"
+
+			cipher._apply_recurrence_and_remap_key()
+
+			# First seen: 89 -> 1, Second seen: 88 -> 2, Third seen: 44 -> 3
+			assert cipher.ciphertext == "1 2 3"
+			assert set(cipher.key["a"]) == {1, 2}
+			assert cipher.key["b"] == [3]
+
+		def test_unused_homophones_are_dropped(self, sample_stream_short):
+			"""Verify that symbols in the key not appearing in ciphertext are removed."""
+			cipher = HomophonicCipher(sample_stream_short)
+			# 77 is assigned to 'a' but never used in the ciphertext
+			cipher.key = {"a": [10, 77], "b": [20]}
+			cipher.ciphertext = "10 20"
+
+			cipher._apply_recurrence_and_remap_key()
+
+			# 10 becomes 1, 20 becomes 2. 77 is missing from ciphertext.
+			assert cipher.key["a"] == [1]
+			assert cipher.key["b"] == [2]
+			assert 77 not in cipher.key["a"]
+   
+	class TestRemappingIntegrity:
+		def test_first_seen_is_always_one(self, sample_stream_short):
+			"""
+			Tests that the actual value of the original symbol doesn't matter; 
+			the first one encountered in the stream MUST become '1'.
+			"""
+			cipher = HomophonicCipher(sample_stream_short)
+			
+			# Scenario A: 'z' is 500, 'a' is 10. Text starts with 'z'.
+			cipher.key = {"z": [500], "a": [10]}
+			cipher.ciphertext = "500 10 500"
+			cipher._apply_recurrence_and_remap_key()
+			assert cipher.ciphertext.startswith("1")
+			assert cipher.key["z"] == [1]
+			assert cipher.key["a"] == [2]
+
+			# Scenario B: Swap the order. 'a' is seen first.
+			cipher.key = {"z": [500], "a": [10]}
+			cipher.ciphertext = "10 500 10"
+			cipher._apply_recurrence_and_remap_key()
+			assert cipher.ciphertext.startswith("1")
+			assert cipher.key["a"] == [1]
+			assert cipher.key["z"] == [2]
+
+		def test_key_value_consistency(self, sample_stream_short):
+			"""
+			Verify that if a letter has multiple homophones, the remapping 
+			correctly updates all of them within the key list.
+			"""
+			cipher = HomophonicCipher(sample_stream_short)
+			# 'e' has three homophones. We use them in a specific order.
+			cipher.key = {"e": [100, 200, 300]}
+			cipher.ciphertext = "300 100 200"
+			
+			cipher._apply_recurrence_and_remap_key()
+			
+			# Appearance: 300->1, 100->2, 200->3
+			assert cipher.ciphertext == "1 2 3"
+			# The list in the key should now reflect these new values
+			assert set(cipher.key["e"]) == {1, 2, 3}
+
+		def test_complex_overlap_integrity(self, sample_stream_short):
+			"""
+			Test a complex sequence to ensure no 'collisions' occur during remapping
+			where a new ID accidentally overwrites an unmapped old ID.
+			"""
+			cipher = HomophonicCipher(sample_stream_short)
+			# Setup: Numbers that might overlap with the 1..N range
+			cipher.key = {"a": [1], "b": [2], "c": [3]}
+			# Ciphertext where they appear in reverse order
+			cipher.ciphertext = "3 2 1"
+			
+			cipher._apply_recurrence_and_remap_key()
+			
+			# If mapping is done correctly: 3->1, 2->2, 1->3
+			assert cipher.ciphertext == "1 2 3"
+			assert cipher.key["c"] == [1]
+			assert cipher.key["b"] == [2]
+			assert cipher.key["a"] == [3]
+
+		def test_key_remains_int_types(self, sample_stream_short):
+			"""
+			Ensure the remapped key contains integers (for JSON) 
+			while the ciphertext remains a string of numbers.
+			"""
+			cipher = HomophonicCipher(sample_stream_short)
+			cipher.key = {"a": [123]}
+			cipher.ciphertext = "123"
+			
+			cipher._apply_recurrence_and_remap_key()
+			
+			assert isinstance(cipher.key["a"][0], int)
+			assert isinstance(cipher.ciphertext.split()[0], str)
+
 
 # --- MonoalphabeticCipher Tests ---
 
 
 class TestMonoalphabeticCipher:
-    def test_legal_plaintext(self, sample_stream_short):
-        # FIX: Pass stream dict, not string
-        cipher = MonoalphabeticCipher(sample_stream_short)
+	def test_legal_plaintext(self, sample_stream_short):
+		# FIX: Pass stream dict, not string
+		cipher = MonoalphabeticCipher(sample_stream_short)
 
-        assert cipher.plaintext == sample_stream_short["text"]
-        assert cipher.source_id == sample_stream_short["source_id"]
-        assert cipher.source_name == sample_stream_short["source_name"]
+		assert cipher.plaintext == sample_stream_short["text"]
+		assert cipher.source_id == sample_stream_short["source_id"]
+		assert cipher.source_name == sample_stream_short["source_name"]
 
-        assert isinstance(cipher.key, dict)
-        assert all(isinstance(v, list) and len(v) == 1 for v in cipher.key.values())
-        assert isinstance(cipher.ciphertext, str)
-        assert all(num.isdigit() for num in cipher.ciphertext.split())
+		assert isinstance(cipher.key, dict)
+		assert all(isinstance(v, list) and len(v) == 1 for v in cipher.key.values())
+		assert isinstance(cipher.ciphertext, str)
+		assert all(num.isdigit() for num in cipher.ciphertext.split())
 
-    def test_key_structure(self, sample_stream_short):
-        cipher = MonoalphabeticCipher(sample_stream_short)
+	def test_key_structure(self, sample_stream_short):
+		cipher = MonoalphabeticCipher(sample_stream_short)
 
-        assert len(cipher.key) == 26
-        for letter in "abcdefghijklmnopqrstuvwxyz":
-            assert letter in cipher.key
-            assert len(cipher.key[letter]) == 1
+		assert len(cipher.key) == 26
+		for letter in "abcdefghijklmnopqrstuvwxyz":
+			assert letter in cipher.key
+			assert len(cipher.key[letter]) == 1
 
-        all_numbers = [cipher.key[letter][0] for letter in "abcdefghijklmnopqrstuvwxyz"]
-        assert sorted(all_numbers) == list(range(1, 27))
-        assert len(set(all_numbers)) == 26
+		all_numbers = [cipher.key[letter][0] for letter in "abcdefghijklmnopqrstuvwxyz"]
+		assert sorted(all_numbers) == list(range(1, 27))
+		assert len(set(all_numbers)) == 26
 
-    def test_randomization(self, sample_stream_short):
-        cipher1 = MonoalphabeticCipher(sample_stream_short)
-        cipher2 = MonoalphabeticCipher(sample_stream_short)
+	def test_ciphertext_length(self, sample_stream_short):
+		cipher = MonoalphabeticCipher(sample_stream_short)
+		ciphertext_numbers = cipher.ciphertext.split()
+		assert len(ciphertext_numbers) == len(sample_stream_short["text"])
 
-        key1_numbers = [cipher1.key[letter][0] for letter in "abcde"]
-        key2_numbers = [cipher2.key[letter][0] for letter in "abcde"]
+	def test_json_serialization_success(self, sample_stream_short):
+		"""
+		FIX: This previously expected failure. Now that MonoalphabeticCipher
+		sets source_id/name, serialization should SUCCEED.
+		"""
+		cipher = MonoalphabeticCipher(sample_stream_short)
+		json_data = cipher.__json__()
 
-        assert key1_numbers != key2_numbers, "Keys should be randomized"
+		assert isinstance(json_data, dict)
+		assert json_data["plaintext"] == sample_stream_short["text"]
+		assert json_data["source_id"] == sample_stream_short["source_id"]
+		assert json_data["source_name"] == sample_stream_short["source_name"]
+		assert json_data["key"] == cipher.key
+		assert json_data["ciphertext"] == cipher.ciphertext
 
-    def test_ciphertext_length(self, sample_stream_short):
-        cipher = MonoalphabeticCipher(sample_stream_short)
-        ciphertext_numbers = cipher.ciphertext.split()
-        assert len(ciphertext_numbers) == len(sample_stream_short["text"])
+	def test_str_representation(self, sample_stream_short):
+		cipher = MonoalphabeticCipher(sample_stream_short)
+		str_repr = str(cipher)
+		assert 'MonoalphabeticCipher(Plaintext: "' in str_repr
+		assert f'"{sample_stream_short["text"]}"' in str_repr
+		assert f"Key: {cipher.key}" in str_repr
+		assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
 
-    def test_json_serialization_success(self, sample_stream_short):
-        """
-        FIX: This previously expected failure. Now that MonoalphabeticCipher
-        sets source_id/name, serialization should SUCCEED.
-        """
-        cipher = MonoalphabeticCipher(sample_stream_short)
-        json_data = cipher.__json__()
+	def test_illegal_plaintext(self, sample_texts_illegal):
+		for text in sample_texts_illegal:
+			# FIX: Wrap illegal text in a TextStream dict structure
+			bad_stream = {
+				"text": text,
+				"source_id": "1",
+				"source_name": "test",
+				"length": len(text),
+			}
 
-        assert isinstance(json_data, dict)
-        assert json_data["plaintext"] == sample_stream_short["text"]
-        assert json_data["source_id"] == sample_stream_short["source_id"]
-        assert json_data["source_name"] == sample_stream_short["source_name"]
-        assert json_data["key"] == cipher.key
-        assert json_data["ciphertext"] == cipher.ciphertext
+			with pytest.raises(ValueError) as excinfo:
+				MonoalphabeticCipher(bad_stream)  # type: ignore
 
-    def test_str_representation(self, sample_stream_short):
-        cipher = MonoalphabeticCipher(sample_stream_short)
-        str_repr = str(cipher)
-        assert 'MonoalphabeticCipher(Plaintext: "' in str_repr
-        assert f'"{sample_stream_short["text"]}"' in str_repr
-        assert f"Key: {cipher.key}" in str_repr
-        assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
+			# Use the error message from validate_text_obj
+			assert (
+				"must include a non-empty, lowercase alphabetic string with no spaces"
+				in str(excinfo.value)
+			)
 
-    def test_illegal_plaintext(self, sample_texts_illegal):
-        for text in sample_texts_illegal:
-            # FIX: Wrap illegal text in a TextStream dict structure
-            bad_stream = {
-                "text": text,
-                "source_id": "1",
-                "source_name": "test",
-                "length": len(text)
-            }
+	def test_non_dict_input(self):
+		# FIX: The validator now checks if input is a dict/TextStream
+		for invalid_input in [12345, None, 5.67, "just a string"]:
+			with pytest.raises(TypeError):
+				MonoalphabeticCipher(invalid_input)  # type: ignore
 
-            with pytest.raises(ValueError) as excinfo:
-                MonoalphabeticCipher(bad_stream) # type: ignore
-
-            # Use the error message from validate_text_obj
-            assert (
-                "must include a non-empty, lowercase alphabetic string with no spaces"
-                in str(excinfo.value)
-            )
-
-    def test_non_dict_input(self):
-        # FIX: The validator now checks if input is a dict/TextStream
-        for invalid_input in [12345, None, 5.67, "just a string"]:
-            with pytest.raises(TypeError):
-                MonoalphabeticCipher(invalid_input) # type: ignore
-
-    def test_empty_string_plaintext(self):
-        bad_stream = {
-            "text": "",
-            "source_id": "1",
-            "source_name": "test",
-            "length": 0
-        }
-        with pytest.raises(ValueError) as excinfo:
-            MonoalphabeticCipher(bad_stream) # type: ignore
-        assert (
-            "must include a non-empty, lowercase alphabetic string"
-            in str(excinfo.value)
-        )
+	def test_empty_string_plaintext(self, bad_streams):
+		for bad_stream in bad_streams:
+			with pytest.raises(ValueError) as excinfo:
+				MonoalphabeticCipher(bad_stream)  # type: ignore
+			assert "must include a non-empty, lowercase alphabetic string" in str(
+				excinfo.value
+			)


### PR DESCRIPTION
## Summary
This PR refactors the internal representation of ciphers to enforce **Recurrence Encoding** as the primary format for `ciphertext` and `key` data. By remapping arbitrary cipher symbols to a normalized $1..N$ sequence based on their order of appearance, the data becomes more consistent for downstream training tasks.

## Key Changes

### 1. Internal Normalization Logic (`src/encipherment/cipher.py`)
* **Unified State**: Removed the `recurrence_encoding` attribute. The `ciphertext` field itself now stores the encoded sequence, and the `key` is automatically remapped to match these new symbols.
* **Automatic Remapping**: Introduced `_apply_recurrence_and_remap_key()`. This method performs a single pass over the generated ciphertext to:
    1. Map each unique homophone to a sequence ID ($1, 2, 3 \dots$).
    2. Update the `ciphertext` string with these IDs.
    3. Remap the `self.key` dictionary so the character-to-homophone mappings align with the new IDs.
* **Metadata Integrity**: Ensured that remapped keys maintain integer types for JSON compatibility while `ciphertext` remains a space-separated string of numbers.

### 2. Consistency across Cipher Types
* **Homophonic & Monoalphabetic**: Both classes now trigger the remapping logic at the end of the `encipher()` process, ensuring that regardless of the encryption method, the output format is identical.
* **JSON Serialization**: Cleaned up the `__json__` and `from_json` methods to reflect the removal of the redundant recurrence attribute.

### 3. Comprehensive Testing Update (`test/encipherment/test_cipher.py`)
* **Remapping Logic Tests**: Added a new suite `TestApplyRecurrenceAndRemapKey` to verify:
    * **Standard Logic**: Arbitrary symbols (e.g., $99, 10, 50$) correctly map to $1, 2, 3$.
    * **Integrity**: First-seen symbols are always assigned ID `1`.
    * **Homophone Handling**: Multiple homophones for a single letter are correctly tracked and remapped to distinct IDs.
    * **Pruning**: Unused homophones present in the key but not the ciphertext are dropped during remapping.
* **Edge Cases**: Added tests for complex overlaps (where original IDs might conflict with the $1..N$ range) and strengthened input validation testing with `bad_streams` fixtures.

## Architectural Impact
By moving recurrence encoding from an optional metadata field to the core data format, we simplify the data pipeline. Consumers (such as model trainers) no longer need to perform this normalization manually, and the stored ZIP files are significantly more uniform.

## Refactoring Note
Updated `src/utils/cipher_conversion.py` and `src/main.py` to remove legacy calls to the old encoding generator, as the process is now encapsulated within the cipher classes themselves.