### PR TITLE
Implementation of Word Boundary Persistence in Cipher Models

### DIFF
--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -51,6 +51,7 @@ class SubstitutionCipher(ABC):
 	) -> None:  # pragma: no cover
 		"""Initialize the Cipher object with the given plaintext."""
 		self.plaintext = text_obj["text"]
+		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]
 		self.difficulty = difficulty
 		self.num_symbols = 0
 		self.key = {}
@@ -94,6 +95,7 @@ class SubstitutionCipher(ABC):
 		"""
 		return {
 			"plaintext": self.plaintext,
+			"plaintext_with_boundaries": self.plaintext_with_boundaries,
 			"length": len(self.plaintext),
 			"num_symbols": self.num_symbols,
 			"difficulty": self.difficulty,
@@ -132,6 +134,7 @@ class SubstitutionCipher(ABC):
 		"""Create a cipher object from a JSON string."""
 		data = json.loads(json_data)
 		cipher = cls(data["plaintext"])
+		cipher.plaintext_with_boundaries = data["plaintext_with_boundaries"]
 		cipher.key = data["key"]
 		cipher.ciphertext = data["ciphertext"]
 		cipher.num_symbols = data["num_symbols"]
@@ -188,6 +191,7 @@ class HomophonicCipher(SubstitutionCipher):
 
 		"""
 		self.plaintext = text_obj["text"]
+		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]
 		if not difficulty:
 			self.difficulty = self.generate_difficulty()
 		else:
@@ -304,6 +308,7 @@ class MonoalphabeticCipher(SubstitutionCipher):
 
 		"""
 		self.plaintext = text_obj["text"]
+		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]
 		self.num_symbols = 0
 		self.key = self.generate_key()
 		self.difficulty = 1

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -56,6 +56,7 @@ class SubstitutionCipher(ABC):
 		self.num_symbols = 0
 		self.key = {}
 		self.ciphertext = ""
+		self.ciphertext_with_boundaries = ""
 		self.source_id = text_obj["source_id"]
 		self.source_name = text_obj["source_name"]
 		raise NotImplementedError("This is an abstract base class.")
@@ -84,6 +85,7 @@ class SubstitutionCipher(ABC):
 
 			new_key[char] = remapped_homophones
 
+
 		self.key = new_key
 
 	def __json__(self) -> dict:
@@ -101,6 +103,7 @@ class SubstitutionCipher(ABC):
 			"difficulty": self.difficulty,
 			"key": self.key,
 			"ciphertext": self.ciphertext,
+			"ciphertext_with_boundaries": self.ciphertext_with_boundaries,
 			"source_id": self.source_id,
 			"source_name": self.source_name,
 		}
@@ -137,6 +140,7 @@ class SubstitutionCipher(ABC):
 		cipher.plaintext_with_boundaries = data["plaintext_with_boundaries"]
 		cipher.key = data["key"]
 		cipher.ciphertext = data["ciphertext"]
+		cipher.ciphertext_with_boundaries = data["ciphertext_with_boundaries"]
 		cipher.num_symbols = data["num_symbols"]
 		cipher.difficulty = data["difficulty"]
 		cipher.source_id = data["source_id"]
@@ -199,6 +203,7 @@ class HomophonicCipher(SubstitutionCipher):
 		self.num_symbols = 0
 		self.key: dict[str, list] = {}
 		self.ciphertext: str = ""
+		self.ciphertext_with_boundaries: str = ""
 		self.source_id = text_obj["source_id"]
 		self.source_name = text_obj["source_name"]
 

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -90,10 +90,13 @@ class SubstitutionCipher(ABC):
 		self.key = new_key
 
 	def _generate_bounded_ciphertext(self) -> str:
-		"""Generate a ciphertext with spaces replaced with underscores.
+		"""Generate a ciphertext based on the plaintext with word boundaries.
+
+		This method maps the plaintext with word boundaries to the ciphertext
+		with underscores left in place.
 
 		Returns:
-			str: The ciphertext with spaces replaced with underscores.
+			str: The ciphertext with underscores left in place.
 
 		"""
 		ciphertext = iter(self.ciphertext.split())

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -85,8 +85,26 @@ class SubstitutionCipher(ABC):
 
 			new_key[char] = remapped_homophones
 
+		self.ciphertext_with_boundaries = self._generate_bounded_ciphertext()
 
 		self.key = new_key
+
+	def _generate_bounded_ciphertext(self) -> str:
+		"""Generate a ciphertext with spaces replaced with underscores.
+
+		Returns:
+			str: The ciphertext with spaces replaced with underscores.
+
+		"""
+		ciphertext = iter(self.ciphertext.split())
+		bounded_ciphertext = []
+		for char in self.plaintext_with_boundaries:
+			if char == "_":
+				bounded_ciphertext.append("_")
+			else:
+				bounded_ciphertext.append(next(ciphertext))
+
+		return " ".join(bounded_ciphertext)
 
 	def __json__(self) -> dict:
 		"""Return a JSON-serializable representation of the Cipher object.

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -1,7 +1,6 @@
 import pytest
 from encipherment.cipher import HomophonicCipher, MonoalphabeticCipher
 from utils.constants import MIN_DIFFICULTY, MAX_DIFFICULTY
-from fetching.text_splits import TextStream
 
 # --- Fixtures ---
 

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -1,23 +1,20 @@
 import pytest
 from encipherment.cipher import HomophonicCipher, MonoalphabeticCipher
 from utils.constants import MIN_DIFFICULTY, MAX_DIFFICULTY
+from fetching.text_splits import TextStream
 
 # --- Fixtures ---
 
-@pytest.fixture(scope="module")
-def sample_text_short():
-	return "abcdefghijklmnopqrstuvwxyz"
-
 
 @pytest.fixture(scope="module")
-def sample_stream_short(sample_text_short):
-	"""Returns a short valid TextStream dictionary."""
+def sample_stream_short():
+	"""Returns a very short valid TextStream dictionary."""
 	return {
-		"text": sample_text_short,
-		"text_with_boundaries": sample_text_short,
+		"text": "abcbc",
+		"text_with_boundaries": "abc_bc",
 		"source_id": "short_1",
 		"source_name": "Alphabet",
-		"length": len(sample_text_short),
+		"length": len("abcbc"),
 	}
 
 
@@ -193,11 +190,19 @@ class TestHomophonicCipher:
 			json_data = cipher.__json__()
 			assert isinstance(json_data, dict)
 			assert json_data["plaintext"] == valid_text_stream["text"]
+			assert (
+				json_data["plaintext_with_boundaries"]
+				== valid_text_stream["text_with_boundaries"]
+			)
 			assert json_data["source_id"] == valid_text_stream["source_id"]
 			assert json_data["source_name"] == valid_text_stream["source_name"]
 			assert json_data["difficulty"] == cipher.difficulty
 			assert json_data["key"] == cipher.key
 			assert json_data["ciphertext"] == cipher.ciphertext
+			assert (
+				json_data["ciphertext_with_boundaries"]
+				== cipher.ciphertext_with_boundaries
+			)
 
 		def test_str_representation(self, valid_text_stream):
 			cipher = HomophonicCipher(valid_text_stream)
@@ -223,10 +228,8 @@ class TestHomophonicCipher:
 	class TestApplyRecurrenceAndRemapKey:
 		def test_standard_remapping_logic(self, sample_stream_short):
 			"""Verify that arbitrary cipher symbols are remapped to 1..N order."""
+
 			cipher = HomophonicCipher(sample_stream_short)
-			# Manually inject state to test the remapping logic in isolation
-			# Plaintext: abc... (from sample_stream_short)
-			# Let's simulate a ciphertext where 'a'=99, 'b'=10, 'c'=50
 			cipher.key = {"a": [99], "b": [10], "c": [50]}
 			cipher.ciphertext = "99 10 50 10 50"  # Represents "abcbc"
 
@@ -244,30 +247,43 @@ class TestHomophonicCipher:
 			"""Ensure multiple homophones for one letter are mapped to distinct IDs."""
 			cipher = HomophonicCipher(sample_stream_short)
 			# 'a' has two homophones, 'b' has one
-			cipher.key = {"a": [88, 89], "b": [44]}
-			# Sequence: a(89) a(88) b(44)
-			cipher.ciphertext = "89 88 44"
+			cipher.key = {"a": [88], "b": [44, 11], "c": [22]}
+			cipher.ciphertext = "88 44 22 11 22"
 
 			cipher._apply_recurrence_and_remap_key()
 
 			# First seen: 89 -> 1, Second seen: 88 -> 2, Third seen: 44 -> 3
-			assert cipher.ciphertext == "1 2 3"
-			assert set(cipher.key["a"]) == {1, 2}
-			assert cipher.key["b"] == [3]
+			assert cipher.ciphertext == "1 2 3 4 3"
+			assert set(cipher.key["a"]) == {1}
+			assert set(cipher.key["b"]) == {2, 4}
+			assert set(cipher.key["c"]) == {3}
 
 		def test_unused_homophones_are_dropped(self, sample_stream_short):
 			"""Verify that symbols in the key not appearing in ciphertext are removed."""
 			cipher = HomophonicCipher(sample_stream_short)
 			# 77 is assigned to 'a' but never used in the ciphertext
-			cipher.key = {"a": [10, 77], "b": [20]}
-			cipher.ciphertext = "10 20"
+			cipher.key = {"a": [10], "b": [20], "c": [77, 11]}
+			cipher.ciphertext = "10 20 11 20 77"
 
 			cipher._apply_recurrence_and_remap_key()
 
 			# 10 becomes 1, 20 becomes 2. 77 is missing from ciphertext.
-			assert cipher.key["a"] == [1]
-			assert cipher.key["b"] == [2]
+			assert set(cipher.key["a"]) == {1}
+			assert set(cipher.key["b"]) == {2}
+			assert set(cipher.key["c"]) == {3, 4}
 			assert 77 not in cipher.key["a"]
+
+		def test_generate_bounded_ciphertext_logic(self, sample_stream_short):
+			"""Verify that underscores from plaintext are perfectly mirrored into ciphertext."""
+			cipher = HomophonicCipher(sample_stream_short)
+
+			cipher.key = {"a": [99], "b": [10], "c": [50]}
+			cipher.ciphertext = "99 10 50 10 50"
+
+			cipher._apply_recurrence_and_remap_key()
+
+			assert cipher.ciphertext == "1 2 3 2 3"
+			assert cipher.ciphertext_with_boundaries == "1 2 3 _ 2 3"
 
 	class TestRemappingIntegrity:
 		def test_first_seen_is_always_one(self, sample_stream_short):
@@ -277,38 +293,22 @@ class TestHomophonicCipher:
 			"""
 			cipher = HomophonicCipher(sample_stream_short)
 
-			# Scenario A: 'z' is 500, 'a' is 10. Text starts with 'z'.
-			cipher.key = {"z": [500], "a": [10]}
-			cipher.ciphertext = "500 10 500"
+			cipher.key = {"a": [10], "b": [20], "c": [30]}
+			cipher.ciphertext = "10 20 30 20 30"
 			cipher._apply_recurrence_and_remap_key()
 			assert cipher.ciphertext.startswith("1")
-			assert cipher.key["z"] == [1]
-			assert cipher.key["a"] == [2]
+			assert set(cipher.key["a"]) == {1}
+			assert set(cipher.key["b"]) == {2}
+			assert set(cipher.key["c"]) == {3}
 
-			# Scenario B: Swap the order. 'a' is seen first.
-			cipher.key = {"z": [500], "a": [10]}
-			cipher.ciphertext = "10 500 10"
+			# Swap the order. 'c' is seen first.
+			cipher.ciphertext = "30 10 30 20 10"
+			cipher.key = {"a": [10], "b": [20], "c": [30]}
 			cipher._apply_recurrence_and_remap_key()
 			assert cipher.ciphertext.startswith("1")
-			assert cipher.key["a"] == [1]
-			assert cipher.key["z"] == [2]
-
-		def test_key_value_consistency(self, sample_stream_short):
-			"""
-			Verify that if a letter has multiple homophones, the remapping
-			correctly updates all of them within the key list.
-			"""
-			cipher = HomophonicCipher(sample_stream_short)
-			# 'e' has three homophones. We use them in a specific order.
-			cipher.key = {"e": [100, 200, 300]}
-			cipher.ciphertext = "300 100 200"
-
-			cipher._apply_recurrence_and_remap_key()
-
-			# Appearance: 300->1, 100->2, 200->3
-			assert cipher.ciphertext == "1 2 3"
-			# The list in the key should now reflect these new values
-			assert set(cipher.key["e"]) == {1, 2, 3}
+			assert set(cipher.key["c"]) == {1}
+			assert set(cipher.key["a"]) == {2}
+			assert set(cipher.key["b"]) == {3}
 
 		def test_complex_overlap_integrity(self, sample_stream_short):
 			"""
@@ -317,93 +317,88 @@ class TestHomophonicCipher:
 			"""
 			cipher = HomophonicCipher(sample_stream_short)
 			# Setup: Numbers that might overlap with the 1..N range
-			cipher.key = {"a": [1], "b": [2], "c": [3]}
+			cipher.key = {"a": [3], "b": [2], "c": [1]}
 			# Ciphertext where they appear in reverse order
-			cipher.ciphertext = "3 2 1"
+			cipher.ciphertext = "3 2 1 2 1"
 
 			cipher._apply_recurrence_and_remap_key()
 
 			# If mapping is done correctly: 3->1, 2->2, 1->3
-			assert cipher.ciphertext == "1 2 3"
-			assert cipher.key["c"] == [1]
+			assert cipher.ciphertext == "1 2 3 2 3"
+			assert cipher.key["a"] == [1]
 			assert cipher.key["b"] == [2]
-			assert cipher.key["a"] == [3]
-
-		def test_key_remains_int_types(self, sample_stream_short):
-			"""
-			Ensure the remapped key contains integers (for JSON)
-			while the ciphertext remains a string of numbers.
-			"""
-			cipher = HomophonicCipher(sample_stream_short)
-			cipher.key = {"a": [123]}
-			cipher.ciphertext = "123"
-
-			cipher._apply_recurrence_and_remap_key()
-
-			assert isinstance(cipher.key["a"][0], int)
-			assert isinstance(cipher.ciphertext.split()[0], str)
+			assert cipher.key["c"] == [3]
 
 
 # --- MonoalphabeticCipher Tests ---
 
 
 class TestMonoalphabeticCipher:
-	def test_legal_plaintext(self, sample_stream_short):
-		# FIX: Pass stream dict, not string
-		cipher = MonoalphabeticCipher(sample_stream_short)
+	def test_legal_plaintext(self, valid_text_stream):
+		cipher = MonoalphabeticCipher(valid_text_stream)
 
-		assert cipher.plaintext == sample_stream_short["text"]
-		assert cipher.source_id == sample_stream_short["source_id"]
-		assert cipher.source_name == sample_stream_short["source_name"]
+		assert cipher.plaintext == valid_text_stream["text"]
+		assert cipher.source_id == valid_text_stream["source_id"]
+		assert cipher.source_name == valid_text_stream["source_name"]
 
 		assert isinstance(cipher.key, dict)
 		assert all(isinstance(v, list) and len(v) == 1 for v in cipher.key.values())
 		assert isinstance(cipher.ciphertext, str)
 		assert all(num.isdigit() for num in cipher.ciphertext.split())
 
+		assert cipher.plaintext_with_boundaries == valid_text_stream["text_with_boundaries"]
+		assert isinstance(cipher.ciphertext_with_boundaries, str)
+		assert len(cipher.ciphertext_with_boundaries) >= len(cipher.ciphertext)
+
 	def test_key_structure(self, sample_stream_short):
 		cipher = MonoalphabeticCipher(sample_stream_short)
 
-		assert len(cipher.key) == 26
-		for letter in "abcdefghijklmnopqrstuvwxyz":
+		assert len(cipher.key) == 3
+		for letter in cipher.plaintext:
 			assert letter in cipher.key
-			assert len(cipher.key[letter]) == 1
+			assert len(cipher.key[letter]) >= 1
 
-		all_numbers = [cipher.key[letter][0] for letter in "abcdefghijklmnopqrstuvwxyz"]
-		assert sorted(all_numbers) == list(range(1, 27))
-		assert len(set(all_numbers)) == 26
+		all_numbers = [cipher.key[letter][0] for letter in cipher.plaintext]
+		assert set(all_numbers) == set(range(1, 4))
+		assert len(set(all_numbers)) == 3
 
-	def test_ciphertext_length(self, sample_stream_short):
-		cipher = MonoalphabeticCipher(sample_stream_short)
+	def test_ciphertext_length(self, valid_text_stream):
+		cipher = MonoalphabeticCipher(valid_text_stream)
 		ciphertext_numbers = cipher.ciphertext.split()
-		assert len(ciphertext_numbers) == len(sample_stream_short["text"])
+		assert len(ciphertext_numbers) == len(valid_text_stream["text"])
 
-	def test_json_serialization_success(self, sample_stream_short):
+	def test_json_serialization_success(self, valid_text_stream):
 		"""
 		FIX: This previously expected failure. Now that MonoalphabeticCipher
 		sets source_id/name, serialization should SUCCEED.
 		"""
-		cipher = MonoalphabeticCipher(sample_stream_short)
+		cipher = MonoalphabeticCipher(valid_text_stream)
 		json_data = cipher.__json__()
 
 		assert isinstance(json_data, dict)
-		assert json_data["plaintext"] == sample_stream_short["text"]
-		assert json_data["source_id"] == sample_stream_short["source_id"]
-		assert json_data["source_name"] == sample_stream_short["source_name"]
+		assert json_data["plaintext"] == valid_text_stream["text"]
+		assert (
+			json_data["plaintext_with_boundaries"]
+			== valid_text_stream["text_with_boundaries"]
+		)
+		assert (
+			json_data["ciphertext_with_boundaries"] == cipher.ciphertext_with_boundaries
+		)
+		assert json_data["source_id"] == valid_text_stream["source_id"]
+		assert json_data["source_name"] == valid_text_stream["source_name"]
 		assert json_data["key"] == cipher.key
 		assert json_data["ciphertext"] == cipher.ciphertext
 
-	def test_str_representation(self, sample_stream_short):
-		cipher = MonoalphabeticCipher(sample_stream_short)
+	def test_str_representation(self, valid_text_stream):
+		cipher = MonoalphabeticCipher(valid_text_stream)
 		str_repr = str(cipher)
 		assert 'MonoalphabeticCipher(Plaintext: "' in str_repr
-		assert f'"{sample_stream_short["text"]}"' in str_repr
+		assert f'"{valid_text_stream["text"]}"' in str_repr
 		assert f"Key: {cipher.key}" in str_repr
 		assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
 
 	def test_illegal_plaintext(self, sample_stream_illegal):
 		for text_obj in sample_stream_illegal:
-
 			with pytest.raises(ValueError) as excinfo:
 				MonoalphabeticCipher(text_obj)  # type: ignore
 


### PR DESCRIPTION
This PR updates the cipher generation pipeline to ingest, process, and serialize word boundaries. By introducing `text_with_boundaries` (where spaces are represented as underscores), the system can now generate a secondary ciphertext output that mirrors the original linguistic structure of the plaintext.

## Key Changes

### 1. Cipher Models (`src/encipherment/cipher.py`)
- **Initialization:** Updated the base `Cipher` and specific implementations (`HomophonicCipher`, `MonoalphabeticCipher`) to accept and store `text_with_boundaries`.
- **New Logic:** Added `_generate_bounded_ciphertext()`. This method uses an iterator to map encrypted symbols back onto the bounded plaintext structure, preserving `_` tokens in their original positions.
- **Serialization:** Updated `__json__` and `from_json` to include:
    - `plaintext_with_boundaries`
    - `ciphertext_with_boundaries`

### 2. Text Fetching & Processing (`src/fetching/text_splits.py`)
- **TypedDict Update:** Updated `TextStream` definition to require `text_with_boundaries`.
- **Chunk Extraction:** Refactored `extract_random_chunk` and `get_book_chunks` to return tuples containing both the spaceless "clean" text and the "bounded" text.
- **Validation:** Removed `clean_whitespace` in favor of more robust boundary-preserving logic during extraction.

### 3. Utility & Validation (`src/utils/validators.py`)
- **Dynamic Validation:** Refactored `validate_text_obj` to use `TextStream.__annotations__.keys()`. This ensures that the validator automatically stays in sync with any future changes to the text object schema.

### 4. Test Suite Enhancements
- Updated fixtures in `conftest.py` to include `sample_text_with_boundaries`.
- Added unit tests for the remapping logic to ensure underscores are perfectly mirrored in the final ciphertext.
- Updated `TestGenerateCipherLogic` to reflect the new `TextStream` requirements.

## Technical Notes

> [!IMPORTANT]
> **Mapping Logic:** The `_generate_bounded_ciphertext` method assumes a 1:1 parity between the spaceless ciphertext IDs and the non-underscore characters in the bounded plaintext. This is guaranteed by the current `encipher()` implementation.

This PR is dependent on the merge of PR #5 

## Acceptance Criteria (From related issue)
- [x] **Model Initialization:** Ciphers correctly store the new bounded plaintext without altering the core `length` property.
- [x] **Passthrough Logic:** `encipher()` successfully maps characters while leaving all `\_` tokens untouched and in their original positions.
- [x] **Serialization:** `create_cipher_json` outputs a final dictionary with all 4 text fields.
- [x] **Unit Tests:** Cipher tests verify the passthrough logic, and serialization tests (using the centralized `MockCipher`) verify the new keys exist in the JSON.