### PR TITLE
Refactor: Multi-dataset interleaving, TypedDict validation, and test suite modernization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,4 @@ jobs:
         run: uv sync
 
       - name: Run Pytest
-        run: uv run pytest
+        run: uv run pytest -m "not integration"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 pythonpath = ["src"]
 testpaths = ["test"]
 addopts = "-v --tb=short --cov=src --cov-report=term-missing"
+markers = [
+	"integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
+]
 
 [tool.coverage.report]
 exclude_also = [

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from parameter_validator import parameter_validator, all_of
 import json
 from utils.text_splits import TextStream
-from utils.validators import validate_text_obj
+from utils.validators import validate_typed_dict
 
 from utils.validators import (
 	in_range,
@@ -201,7 +201,7 @@ class HomophonicCipher(SubstitutionCipher):
 	"""
 
 	@parameter_validator(
-		text_obj=validate_text_obj,
+		text_obj=validate_typed_dict,
 		difficulty=all_of(
 			in_range(MIN_DIFFICULTY, MAX_DIFFICULTY),
 			strongly_typed_optional,
@@ -329,7 +329,7 @@ class MonoalphabeticCipher(SubstitutionCipher):
 
 	"""
 
-	@parameter_validator(text_obj=validate_text_obj)
+	@parameter_validator(text_obj=validate_typed_dict)
 	def __init__(self, text_obj: TextStream) -> None:
 		"""Initialize the MonoalphabeticCipher with the given text object.
 

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -7,11 +7,12 @@ from abc import ABC, abstractmethod
 from parameter_validator import parameter_validator, all_of
 import json
 from utils.text_splits import TextStream
-from utils.validators import validate_typed_dict
 
 from utils.validators import (
 	in_range,
 	strongly_typed_optional,
+	validate_typed_dict,
+	is_alpha_lowercase_no_spaces,
 )
 
 
@@ -79,9 +80,7 @@ class SubstitutionCipher(ABC):
 		new_key = {}
 		for char, homophones in self.key.items():
 			remapped_homophones = [
-				int(symbol_map[str(h)])
-				for h in homophones
-				if str(h) in symbol_map
+				int(symbol_map[str(h)]) for h in homophones if str(h) in symbol_map
 			]
 
 			new_key[char] = remapped_homophones
@@ -218,6 +217,12 @@ class HomophonicCipher(SubstitutionCipher):
 				("homophonic" or "monoalphabetic").
 
 		"""
+		if not text_obj["text"]:
+			raise ValueError("Plaintext must be a non-empty string.")
+		if not is_alpha_lowercase_no_spaces(text_obj["text"]):
+			raise ValueError(
+				"Plaintext must be a lowercase alphabetic string with no spaces."
+			)
 		self.plaintext = text_obj["text"]
 		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]
 		if not difficulty:
@@ -337,6 +342,12 @@ class MonoalphabeticCipher(SubstitutionCipher):
 			text_obj (TextStream): Text object containing the plaintext and metadata.
 
 		"""
+		if not text_obj["text"]:
+			raise ValueError("Plaintext must be a non-empty string.")
+		if not is_alpha_lowercase_no_spaces(text_obj["text"]):
+			raise ValueError(
+				"Plaintext must be a lowercase alphabetic string with no spaces."
+			)
 		self.plaintext = text_obj["text"]
 		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]
 		self.num_symbols = 0

--- a/src/encipherment/cipher.py
+++ b/src/encipherment/cipher.py
@@ -221,7 +221,7 @@ class HomophonicCipher(SubstitutionCipher):
 			raise ValueError("Plaintext must be a non-empty string.")
 		if not is_alpha_lowercase_no_spaces(text_obj["text"]):
 			raise ValueError(
-				"Plaintext must be a lowercase alphabetic string with no spaces."
+				"Plaintext must be a lowercase alphabetic string with no spaces.",
 			)
 		self.plaintext = text_obj["text"]
 		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]
@@ -346,7 +346,7 @@ class MonoalphabeticCipher(SubstitutionCipher):
 			raise ValueError("Plaintext must be a non-empty string.")
 		if not is_alpha_lowercase_no_spaces(text_obj["text"]):
 			raise ValueError(
-				"Plaintext must be a lowercase alphabetic string with no spaces."
+				"Plaintext must be a lowercase alphabetic string with no spaces.",
 			)
 		self.plaintext = text_obj["text"]
 		self.plaintext_with_boundaries = text_obj["text_with_boundaries"]

--- a/src/fetching/corpus_sampler.py
+++ b/src/fetching/corpus_sampler.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Iterable
+from typing import Iterator, Iterable, TypedDict
 from itertools import islice
 
 from utils.constants import BOOK_IDS_VALIDATION, TOTAL_BOOKS
@@ -10,18 +10,21 @@ from utils.text_splits import (
 	TextStream,
 )
 
-from utils.validators import validate_targets
+from utils.validators import validate_typed_dict
 from parameter_validator import parameter_validator
 
-
+class Targets(TypedDict):
+	train: int
+	val: int
+	test: int
 
 class CorpusSampler:
 	"""Manages the stateful extraction of texts across dataset splits."""
 
-	@parameter_validator(targets=validate_targets)
+	@parameter_validator(targets=validate_typed_dict)
 	def __init__(
 		self,
-		targets: dict[str, int],
+		targets: Targets,
 		len_bounds: tuple[int, int],
 		genre_map: dict[str, list[str]],
 	) -> None:

--- a/src/fetching/corpus_sampler.py
+++ b/src/fetching/corpus_sampler.py
@@ -14,6 +14,8 @@ from utils.validators import validate_typed_dict
 from parameter_validator import parameter_validator
 
 class Targets(TypedDict):
+	"""A typed dictionary for target counts."""
+
 	train: int
 	val: int
 	test: int

--- a/src/fetching/dataset_extractor.py
+++ b/src/fetching/dataset_extractor.py
@@ -101,6 +101,25 @@ class DatasetExtractor:
 
 		return clean_title or "unknown"
 
+	def _normalize_record(self, x: dict, p: str, t: str, fg: list[str]) -> dict:
+		"""Normalize individual records and safely map metadata."""
+		metadata = x.get("metadata", {})
+		source_name = "unknown"
+		if isinstance(metadata, dict):
+			source_name = metadata.get("title", "unknown")
+
+		if source_name == "unknown":
+			source_name = self._extract_title_from_text(x["text"])
+
+		return {
+			"id": str(x.get("id", "unknown")),
+			"text": x["text"],
+			"source_name": source_name,
+			"prefix": p,
+			"source_type": t,
+			"fallback_genres": fg,
+		}
+
 	def get_full_stream(self) -> IterableDataset:
 		"""Get the full Hugging Face stream.
 
@@ -128,31 +147,10 @@ class DatasetExtractor:
 			source_type = config.get("type", "unknown")
 			fallback_genres = config.get("fallback_genres", ["Other / Uncategorized"])
 
-			def _normalize_record(
-				x: dict,
-				p: str = prefix,
-				t: str = source_type,
-				fg: list[str] = fallback_genres,
-			) -> dict:
-				"""Normalize individual records and safely map metadata."""
-				metadata = x.get("metadata", {})
-				source_name = "unknown"
-				if isinstance(metadata, dict):
-					source_name = metadata.get("title", "unknown")
-
-				if source_name == "unknown":
-					source_name = self._extract_title_from_text(x["text"])
-
-				return {
-					"id": str(x.get("id", "unknown")),
-					"text": x["text"],
-					"source_name": source_name,
-					"prefix": p,
-					"source_type": t,
-					"fallback_genres": fg,
-				}
-
-			ds = ds.map(_normalize_record)
+			ds = ds.map(
+				self._normalize_record,
+				fn_kwargs={"p": prefix, "t": source_type, "fg": fallback_genres},
+			)
 
 			columns = [
 				"id",

--- a/src/fetching/dataset_extractor.py
+++ b/src/fetching/dataset_extractor.py
@@ -90,7 +90,7 @@ class DatasetExtractor:
 		paragraphs = re.split(r"\n\s*\n", text)
 		first_block = paragraphs[0] if paragraphs else text
 
-		title_match = re.match(r"^#\s*(.*)", first_block, flags=re.DOTALL)
+		title_match = re.match(r"^#+\s*(.*)", first_block, flags=re.DOTALL)
 		raw_title = title_match.group(1) if title_match else first_block
 
 		clean_title = re.sub(r"\s+", " ", raw_title).strip()
@@ -99,7 +99,7 @@ class DatasetExtractor:
 		if url_index != -1:
 			clean_title = clean_title[:url_index].strip()
 
-		return clean_title
+		return clean_title or "unknown"
 
 	def get_full_stream(self) -> IterableDataset:
 		"""Get the full Hugging Face stream.

--- a/src/fetching/dataset_extractor.py
+++ b/src/fetching/dataset_extractor.py
@@ -1,34 +1,109 @@
-from datasets import load_dataset
+from datasets import load_dataset, interleave_datasets
 import os
 import dotenv
 import logging
 from datasets import IterableDataset
-from typing import Iterator
+from typing import Iterator, TypedDict
+import re
+
+from utils.text_splits import randomize_stream
 
 dotenv.load_dotenv()
+
+
+class DatasetConfig(TypedDict):
+	"""A typed dictionary for dataset configurations.
+
+	Attributes:
+		path (str): The path to the dataset.
+		type (str): The type of dataset.
+		split_name (str): The name of the split to extract.
+		column (str): The column to extract.
+		prefix (str): The prefix to add to the ids.
+		fallback_genres (list[str]): The list of genres to use if the column is missing.
+
+	"""
+
+	path: str
+	type: str
+	split_name: str
+	column: str
+	prefix: str
+	fallback_genres: list[str]
 
 
 class DatasetExtractor:
 	"""A class for extracting dataset from Hugging Face."""
 
-	def __init__(self, dataset_name: str, logger: logging.Logger | None = None) -> None:
+	def __init__(
+		self,
+		datasets: list[DatasetConfig],
+		logger: logging.Logger | None = None,
+	) -> None:
 		"""Initialize the DatasetExtractor with the dataset name and split.
 
+		The config array should be a list of dictionaries with the following keys:
+		```python
+		{
+			"path": str,
+			"type": str,
+			"split_name": str,
+			"column": str,
+			"prefix": str,
+			"fallback_genres": list[str],
+		}
+		```
+
 		Args:
-			dataset_name (str): The name of the dataset to extract.
-			split (str): The split of the dataset to extract.
+			datasets (list[DatasetConfig]): The list of datasets to extract with their
+				configurations.
 			logger (logging.Logger | None, optional): Logger to use. Defaults to None.
 
 		"""
-		self.dataset_name = dataset_name
+		self.configs = datasets
 		self.token = os.environ.get("HF_TOKEN")
-		# If no logger is provided, create a mock one which will not log anywhere
-		if not logger:
-			self.logger = logging.Logger("DatasetExtractor")
+
+		if logger:
+			self.logger = logger
+		else:
+			self.logger = logging.getLogger("DatasetExtractor")
 			self.logger.addHandler(logging.NullHandler())
 			self.logger.setLevel(logging.CRITICAL)
+
+	def _extract_title_from_text(self, text: str) -> str:
+		"""Extracts a prospective title from the beginning of a raw document.
+
+		Targets Markdown headers or the first distinct text block, normalizing
+		newlines and stripping excess whitespace or appended URLs.
+
+		Args:
+			text (str): The raw text to extract the title from.
+
+		Returns:
+			str: The extracted title.
+
+		"""
+		if not text or not isinstance(text, str):
+			return "unknown"
+
+		text = text.lstrip()
+
+		paragraphs = re.split(r"\n\s*\n", text)
+		first_block = paragraphs[0] if paragraphs else text
+
+		title_match = re.match(r"^#\s*(.*)", first_block, flags=re.DOTALL)
+		if title_match:
+			raw_title = title_match.group(1)
 		else:
-			self.logger = logger
+			raw_title = first_block
+
+		clean_title = re.sub(r"\s+", " ", raw_title).strip()
+
+		url_index = clean_title.find("http")
+		if url_index != -1:
+			clean_title = clean_title[:url_index].strip()
+
+		return clean_title
 
 	def get_full_stream(self) -> IterableDataset:
 		"""Get the full Hugging Face stream.
@@ -37,21 +112,86 @@ class DatasetExtractor:
 			IterableDataset: The full Hugging Face stream.
 
 		"""
-		if hasattr(self, "logger"):
+		if self.logger:
 			self.logger.info("Initializing full Hugging Face stream...")
 
-		return load_dataset(
-			self.dataset_name,
-			split="train",
-			streaming=True,
-			token=self.token,
+		streams = []
+
+		for config in self.configs:
+			ds = load_dataset(
+				config["path"],
+				split=config.get("split_name", "train"),
+				streaming=True,
+				token=self.token,
+			)
+
+			if config["column"] != "text":
+				ds = ds.rename_column(config["column"], "text")
+
+			prefix = config.get("prefix", "unknown")
+			source_type = config.get("type", "unknown")
+			fallback_genres = config.get("fallback_genres", ["Other / Uncategorized"])
+
+			def normalize_record(x, p=prefix, t=source_type, fg=fallback_genres):
+				"""Normalize individual records and safely map metadata."""
+				metadata = x.get("metadata", {})
+				source_name = "unknown"
+				if isinstance(metadata, dict):
+					source_name = metadata.get("title", "unknown")
+
+				if source_name == "unknown":
+					source_name = self._extract_title_from_text(x["text"])
+
+				return {
+					"id": str(x.get("id", "unknown")),
+					"text": x["text"],
+					"source_name": source_name,
+					"prefix": p,
+					"source_type": t,
+					"fallback_genres": fg,
+				}
+
+			ds = ds.map(normalize_record)
+
+			columns = [
+				"id",
+				"text",
+				"source_name",
+				"prefix",
+				"source_type",
+				"fallback_genres",
+			]
+
+			ds = ds.select_columns(columns)
+
+			streams.append(ds)
+
+		return interleave_datasets(
+			streams, seed=42, stopping_strategy="all_exhausted_without_replacement"
 		)
 
-	def get_id_stream(self) -> Iterator[str]:
-		"""Extract book IDs from the dataset while skipping the text payload."""
+	def get_pg_id_stream(self) -> Iterator[str]:
+		"""Extract book IDs from the Project Gutenberg dataset.
+
+		Returns:
+			Iterator[str]: An iterator of book IDs.
+
+		"""
+		dataset_config = next(
+			(
+				config
+				for config in self.configs
+				if config["type"] == "project_gutenberg"
+			),
+			None,
+		)
+
+		if not dataset_config:
+			raise ValueError("No Project Gutenberg dataset found in config.")
+
 		stream = load_dataset(
-			self.dataset_name,
-			split="train",
+			dataset_config["path"],
+			split=dataset_config.get("split_name", "train"),
 			streaming=True,
 			token=self.token,
 		).select_columns(["id"])

--- a/src/fetching/dataset_extractor.py
+++ b/src/fetching/dataset_extractor.py
@@ -6,7 +6,6 @@ from datasets import IterableDataset
 from typing import Iterator, TypedDict
 import re
 
-from utils.text_splits import randomize_stream
 
 dotenv.load_dotenv()
 
@@ -71,7 +70,7 @@ class DatasetExtractor:
 			self.logger.setLevel(logging.CRITICAL)
 
 	def _extract_title_from_text(self, text: str) -> str:
-		"""Extracts a prospective title from the beginning of a raw document.
+		"""Extract a prospective title from the beginning of a raw document.
 
 		Targets Markdown headers or the first distinct text block, normalizing
 		newlines and stripping excess whitespace or appended URLs.
@@ -92,10 +91,7 @@ class DatasetExtractor:
 		first_block = paragraphs[0] if paragraphs else text
 
 		title_match = re.match(r"^#\s*(.*)", first_block, flags=re.DOTALL)
-		if title_match:
-			raw_title = title_match.group(1)
-		else:
-			raw_title = first_block
+		raw_title = title_match.group(1) if title_match else first_block
 
 		clean_title = re.sub(r"\s+", " ", raw_title).strip()
 
@@ -132,7 +128,12 @@ class DatasetExtractor:
 			source_type = config.get("type", "unknown")
 			fallback_genres = config.get("fallback_genres", ["Other / Uncategorized"])
 
-			def normalize_record(x, p=prefix, t=source_type, fg=fallback_genres):
+			def _normalize_record(
+				x: dict,
+				p: str = prefix,
+				t: str = source_type,
+				fg: list[str] = fallback_genres,
+			) -> dict:
 				"""Normalize individual records and safely map metadata."""
 				metadata = x.get("metadata", {})
 				source_name = "unknown"
@@ -151,7 +152,7 @@ class DatasetExtractor:
 					"fallback_genres": fg,
 				}
 
-			ds = ds.map(normalize_record)
+			ds = ds.map(_normalize_record)
 
 			columns = [
 				"id",
@@ -167,7 +168,9 @@ class DatasetExtractor:
 			streams.append(ds)
 
 		return interleave_datasets(
-			streams, seed=42, stopping_strategy="all_exhausted_without_replacement"
+			streams,
+			seed=42,
+			stopping_strategy="all_exhausted_without_replacement",
 		)
 
 	def get_pg_id_stream(self) -> Iterator[str]:

--- a/src/genre_mapping/genre_mapper.py
+++ b/src/genre_mapping/genre_mapper.py
@@ -54,7 +54,7 @@ class GenreMapper:
 
 		"""
 		final_genre_map = load_existing_genre_map(output_path, self.logger)
-		id_stream = self.extractor.get_id_stream()
+		id_stream = self.extractor.get_pg_id_stream()
 
 		batch_buffer = []
 		newly_mapped_count = 0

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -97,6 +97,7 @@ def _deep_validate(value: Any, type_hint: Any) -> None:
 			f"All elements in '{value}' must be of type {element_type.__name__}.",
 		)
 
+
 def _validate_field(key: str, type_hint: type, dict: dict[str, Any], name: str) -> None:
 	"""Validate a field in a dictionary.
 
@@ -110,9 +111,6 @@ def _validate_field(key: str, type_hint: type, dict: dict[str, Any], name: str) 
 		ValueError: If the value is invalid.
 
 	"""
-	if key not in dict:
-			raise ValueError(f"Missing required key in {name}: '{key}'")
-
 	origin_type = get_origin(type_hint) or type_hint
 
 	if not isinstance(dict[key], origin_type):
@@ -126,7 +124,7 @@ def _validate_field(key: str, type_hint: type, dict: dict[str, Any], name: str) 
 
 
 @validator
-def validate_typed_dict(dict: dict[str, Any], name: str, type_hint: type) -> None:
+def validate_typed_dict(dict_obj: Any, name: str, type_hint: type) -> None:
 	"""Validate a dictionary with a specific type hint.
 
 	Args:
@@ -135,8 +133,19 @@ def validate_typed_dict(dict: dict[str, Any], name: str, type_hint: type) -> Non
 		type_hint (type): The expected type hint.
 
 	Raises:
-		ValueError: If the dictionary is invalid.
+		ValueError: If the dictionary is missing keys or has invalid types.
 
 	"""
+	if not isinstance(dict_obj, dict):
+		raise TypeError(f"Parameter `{name}` must be of type dict.")
+
+	required_keys = set(type_hint.__annotations__.keys())
+	provided_keys = set(dict_obj.keys())
+
+	missing_keys = required_keys - provided_keys
+	if missing_keys:
+		missing_str = ", ".join(f"'{k}'" for k in sorted(missing_keys))
+		raise ValueError(f"Missing required keys in {name}: {missing_str}")
+
 	for key, type_hint_sub in type_hint.__annotations__.items():
-		_validate_field(key, type_hint_sub, dict, name)
+		_validate_field(key, type_hint_sub, dict_obj, name)

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -19,9 +19,7 @@ def in_range(min_value: int, max_value: int) -> Callable:
 
 	@validator
 	def validate(value: int, name: str) -> None:
-		if not isinstance(value, int):
-			return
-		if not (min_value <= value <= max_value):
+		if isinstance(value, int) and not (min_value <= value <= max_value):
 			raise ValueError(
 				f"Parameter `{name}` must be between {min_value} and {max_value}.",
 			)
@@ -29,6 +27,7 @@ def in_range(min_value: int, max_value: int) -> Callable:
 	return validate
 
 
+@validator
 def strongly_typed_optional(value: Any, name: str, type_hint: type) -> None:
 	"""Validate that a parameter is either None or of the expected type.
 
@@ -51,6 +50,7 @@ def strongly_typed_optional(value: Any, name: str, type_hint: type) -> None:
 		)
 
 
+@validator
 def lower_case_no_spaces_alpha_string(value: Any, name: str, type_hint: type) -> None:
 	"""Validate that a string is lowercase and contains no spaces.
 
@@ -90,42 +90,52 @@ def is_alpha_lowercase_no_spaces(value: str) -> bool:
 	return all(c in ALPHABET for c in value)
 
 
-@validator
-def validate_text_obj(value: Any, name: str) -> None:
-	"""Validate that a value is a valid TextStream object.
+def _deep_validate(value: Any, type_hint: Any) -> None:
+	"""Validate on list or dict elements recursively."""
+	element_type = get_args(type_hint)[0]
+	if not all(isinstance(item, element_type) for item in value):
+		raise ValueError(
+			f"All elements in '{value}' must be of type {element_type.__name__}.",
+		)
+  
+def _validate_field(key: str, type_hint: type, dict, name: str) -> None:
+	"""Validate a field in a dictionary.
 
 	Args:
 		value (Any): The value to validate.
 		name (str): The name of the parameter.
+		type_hint (Type): The expected type hint.
 
 	Raises:
-		TypeError: If the value is not a dict.
-		KeyError: If the dict does not contain the required keys.
-		ValueError: If the dict does not contain the required keys.
-
+		ValueError: If the value is invalid.
 	"""
-	if not isinstance(value, dict):
-		raise TypeError(f"Parameter `{name}` must be of type dict.")
+	if key not in dict:
+			raise ValueError(f"Missing required key in {name}: '{key}'")
 
-	required_keys = TextStream.__annotations__.keys()
-	if set(value.keys()) != set(required_keys):
-		raise KeyError(
-			f"Parameter `{name}` must contain the following keys: {str(required_keys)}."
-			f" Missing keys: {set(required_keys) - set(value.keys())}.",
-		)
+	origin_type = get_origin(type_hint) or type_hint
 
-	text_content = value["text"]
-	if not text_content or not is_alpha_lowercase_no_spaces(text_content):
+	if not isinstance(dict[key], origin_type):
 		raise ValueError(
-			f"Parameter `{name}` must include a non-empty, lowercase alphabetic string "
-			"with no spaces in the text field.",
+			f"Invalid type for key '{key}'. "
+			f"Expected {origin_type.__name__}, got {type(dict[key]).__name__}.",
 		)
+
+	if origin_type is list:
+		_deep_validate(dict[key], type_hint)
+
 
 @validator
-def validate_targets(targets: dict[str, int]) -> None:
-	"""Validate the targets dictionary."""
-	required_keys = {"train", "val", "test"}
-	if set(targets.keys()) != required_keys:
-		raise ValueError(
-			f"total_samples_map must contain exactly keys: {required_keys}",
-		)
+def validate_typed_dict(dict: dict[str, Any], name: str, type_hint: type) -> None:
+	"""Validate a dictionary with a specific type hint.
+
+	Args:
+		dict (dict[str, Any]): The dictionary to validate.
+		name (str): The name of the parameter.
+		type_hint (type): The expected type hint.
+
+	Raises:
+		ValueError: If the dictionary is invalid.
+
+	"""
+	for key, type_hint in type_hint.__annotations__.items():
+		_validate_field(key, type_hint, dict, name)

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -2,7 +2,6 @@ from parameter_validator import validator
 from typing import Callable, Any, get_origin, get_args
 from types import UnionType
 from utils.constants import ALPHABET
-from utils.text_splits import TextStream
 
 
 def in_range(min_value: int, max_value: int) -> Callable:
@@ -97,17 +96,19 @@ def _deep_validate(value: Any, type_hint: Any) -> None:
 		raise ValueError(
 			f"All elements in '{value}' must be of type {element_type.__name__}.",
 		)
-  
-def _validate_field(key: str, type_hint: type, dict, name: str) -> None:
+
+def _validate_field(key: str, type_hint: type, dict: dict[str, Any], name: str) -> None:
 	"""Validate a field in a dictionary.
 
 	Args:
-		value (Any): The value to validate.
-		name (str): The name of the parameter.
-		type_hint (Type): The expected type hint.
+		key (str): The key to validate.
+		type_hint (type): The expected type hint.
+		dict (dict[str, Any]): The dictionary to validate.
+		name (str): The name of the dictionary parameter.
 
 	Raises:
 		ValueError: If the value is invalid.
+
 	"""
 	if key not in dict:
 			raise ValueError(f"Missing required key in {name}: '{key}'")
@@ -137,5 +138,5 @@ def validate_typed_dict(dict: dict[str, Any], name: str, type_hint: type) -> Non
 		ValueError: If the dictionary is invalid.
 
 	"""
-	for key, type_hint in type_hint.__annotations__.items():
-		_validate_field(key, type_hint, dict, name)
+	for key, type_hint_sub in type_hint.__annotations__.items():
+		_validate_field(key, type_hint_sub, dict, name)

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -98,13 +98,15 @@ def _deep_validate(value: Any, type_hint: Any) -> None:
 		)
 
 
-def _validate_field(key: str, type_hint: type, dict_obj: dict[str, Any], name: str) -> None:
+def _validate_field(
+	key: str, type_hint: type, dict_obj: dict[str, Any], name: str,
+) -> None:
 	"""Validate a field in a dictionary.
 
 	Args:
 		key (str): The key to validate.
 		type_hint (type): The expected type hint.
-		dict (dict[str, Any]): The dictionary to validate.
+		dict_obj (dict[str, Any]): The dictionary to validate.
 		name (str): The name of the dictionary parameter.
 
 	Raises:

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -128,7 +128,7 @@ def validate_typed_dict(dict_obj: Any, name: str, type_hint: type) -> None:
 	"""Validate a dictionary with a specific type hint.
 
 	Args:
-		dict (dict[str, Any]): The dictionary to validate.
+		dict_obj (dict[str, Any]): The dictionary to validate.
 		name (str): The name of the parameter.
 		type_hint (type): The expected type hint.
 

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -98,7 +98,7 @@ def _deep_validate(value: Any, type_hint: Any) -> None:
 		)
 
 
-def _validate_field(key: str, type_hint: type, dict: dict[str, Any], name: str) -> None:
+def _validate_field(key: str, type_hint: type, dict_obj: dict[str, Any], name: str) -> None:
 	"""Validate a field in a dictionary.
 
 	Args:
@@ -113,14 +113,14 @@ def _validate_field(key: str, type_hint: type, dict: dict[str, Any], name: str) 
 	"""
 	origin_type = get_origin(type_hint) or type_hint
 
-	if not isinstance(dict[key], origin_type):
+	if not isinstance(dict_obj[key], origin_type):
 		raise ValueError(
 			f"Invalid type for key '{key}'. "
-			f"Expected {origin_type.__name__}, got {type(dict[key]).__name__}.",
+			f"Expected {origin_type.__name__}, got {type(dict_obj[key]).__name__}.",
 		)
 
 	if origin_type is list:
-		_deep_validate(dict[key], type_hint)
+		_deep_validate(dict_obj[key], type_hint)
 
 
 @validator

--- a/test/encipherment/test_cipher.py
+++ b/test/encipherment/test_cipher.py
@@ -1,6 +1,8 @@
 import pytest
 from encipherment.cipher import HomophonicCipher, MonoalphabeticCipher
 from utils.constants import MIN_DIFFICULTY, MAX_DIFFICULTY
+from typing import Any
+from dataclasses import dataclass
 
 # --- Fixtures ---
 
@@ -44,19 +46,32 @@ def sample_stream_illegal(sample_texts_illegal):
 	]
 
 
-@pytest.fixture
-def bad_streams():
-	"""Returns a list of invalid TextStream dictionaries for HomophonicCipher."""
-	return [
-		{
+@dataclass
+class BadStreamTestCase:
+	"""Encapsulates parameters for testing invalid TextStream dictionaries."""
+	desc: str
+	stream: dict[str, Any]
+	expected_exception: type[Exception]
+	match: str
+
+
+BAD_STREAM_CASES = [
+	BadStreamTestCase(
+		desc="Invalid: Empty plaintext string",
+		stream={
 			"text": "",
 			"text_with_boundaries": "",
 			"source_id": "book_123",
 			"source_name": "Test Book",
-			"length": len("invalid"),
+			"length": 0,
 			"genres": [],
 		},
-		{
+		expected_exception=ValueError,
+		match="non-empty",
+	),
+	BadStreamTestCase(
+		desc="Invalid: Whitespace only plaintext string",
+		stream={
 			"text": " ",
 			"text_with_boundaries": " ",
 			"source_id": "book_123",
@@ -64,15 +79,23 @@ def bad_streams():
 			"length": 0,
 			"genres": [],
 		},
-		{
-			"text": "inval id",
+		expected_exception=ValueError,
+		match="lowercase alphabetic string with no spaces",
+	),
+	BadStreamTestCase(
+		desc="Invalid: Length is None type",
+		stream={
+			"text": "invalid",
 			"text_with_boundaries": "inval_id",
 			"source_id": "book_123",
 			"source_name": "Test Book",
 			"length": None,
 			"genres": [],
 		},
-	]
+		expected_exception=ValueError,
+		match="Invalid type for key 'length'",
+	),
+]
 
 
 # --- HomophonicCipher Tests ---
@@ -111,12 +134,8 @@ class TestHomophonicCipher:
 				# Wrap illegal text in a TextStream dict structure
 				bad_stream = {"text": text, "source_name": "bad"}
 
-				with pytest.raises(KeyError) as excinfo:
+				with pytest.raises(ValueError, match="Missing required keys"):
 					HomophonicCipher(bad_stream)  # type: ignore
-				assert "text_obj" in str(excinfo.value)
-				assert "Missing keys:" in str(excinfo.value)
-				assert "source_id" in str(excinfo.value)
-				assert "source_name" in str(excinfo.value)
 
 		def test_defined_difficulty(self, valid_text_stream):
 			for difficulty in range(4, 11):
@@ -164,29 +183,11 @@ class TestHomophonicCipher:
 					in str(excinfo.value)
 				)
 
-		def test_non_integer_difficulty(self, valid_text_stream):
-			for non_integer in [5.5, "ten"]:
-				with pytest.raises(TypeError) as excinfo:
-					HomophonicCipher(valid_text_stream, difficulty=non_integer)
-				assert "Parameter `difficulty` must be of type int, or None." in str(
-					excinfo.value
-				)
-
-		def test_non_stream_plaintext(self):
-			# The validator expects text_obj to be the first arg, validation might fail
-			# inside __init__ when accessing ["text"] if input is not subscriptable
-			for invalid_input in [12345, None, 5.67]:
-				with pytest.raises(TypeError):
-					HomophonicCipher(invalid_input)
-
-		def test_empty_string_plaintext_in_stream(self, bad_streams):
-			for bad_stream in bad_streams:
-				with pytest.raises(ValueError) as excinfo:
-					HomophonicCipher(bad_stream)  # type: ignore
-				assert (
-					"must include a non-empty, lowercase alphabetic string with no spaces in the text field."
-					in str(excinfo.value)
-				)
+		@pytest.mark.parametrize("case", BAD_STREAM_CASES, ids=lambda c: c.desc)
+		def test_invalid_stream_initialization(self, case: BadStreamTestCase):
+			"""Test that invalid stream parameters raise the specific expected exceptions."""
+			with pytest.raises(case.expected_exception, match=case.match):
+				HomophonicCipher(case.stream) # type: ignore
 
 	class TestHomophonicSerialization:
 		def test_json_serialization(self, valid_text_stream):
@@ -401,27 +402,8 @@ class TestMonoalphabeticCipher:
 		assert f"Key: {cipher.key}" in str_repr
 		assert f'Ciphertext: "{cipher.ciphertext}"' in str_repr
 
-	def test_illegal_plaintext(self, sample_stream_illegal):
-		for text_obj in sample_stream_illegal:
-			with pytest.raises(ValueError) as excinfo:
-				MonoalphabeticCipher(text_obj)  # type: ignore
-
-			# Use the error message from validate_text_obj
-			assert (
-				"must include a non-empty, lowercase alphabetic string with no spaces"
-				in str(excinfo.value)
-			)
-
-	def test_non_dict_input(self):
-		# FIX: The validator now checks if input is a dict/TextStream
-		for invalid_input in [12345, None, 5.67, "just a string"]:
-			with pytest.raises(TypeError):
-				MonoalphabeticCipher(invalid_input)  # type: ignore
-
-	def test_empty_string_plaintext(self, bad_streams):
-		for bad_stream in bad_streams:
-			with pytest.raises(ValueError) as excinfo:
-				MonoalphabeticCipher(bad_stream)  # type: ignore
-			assert "must include a non-empty, lowercase alphabetic string" in str(
-				excinfo.value
-			)
+	@pytest.mark.parametrize("case", BAD_STREAM_CASES, ids=lambda c: c.desc)
+	def test_invalid_stream_initialization(self, case: BadStreamTestCase):
+		"""Test that invalid stream parameters raise the specific expected exceptions."""
+		with pytest.raises(case.expected_exception, match=case.match):
+			MonoalphabeticCipher(case.stream) # type: ignore

--- a/test/fetching/test_corpus_sampler.py
+++ b/test/fetching/test_corpus_sampler.py
@@ -40,8 +40,8 @@ class TestCorpusSamplerInit:
         """Test that the parameter validator intercepts incorrect dictionary keys."""
         invalid_targets = {"train": 100, "validation": 10}
 
-        with pytest.raises(ValueError, match="must contain exactly keys"):
-            CorpusSampler(invalid_targets, (500, 1000), default_genre_map)
+        with pytest.raises(ValueError, match="Missing required key in targets: 'val'"):
+            CorpusSampler(invalid_targets, (500, 1000), default_genre_map) # type: ignore
 
 
 class TestCorpusSamplerIsComplete:

--- a/test/fetching/test_corpus_sampler.py
+++ b/test/fetching/test_corpus_sampler.py
@@ -40,7 +40,7 @@ class TestCorpusSamplerInit:
         """Test that the parameter validator intercepts incorrect dictionary keys."""
         invalid_targets = {"train": 100, "validation": 10}
 
-        with pytest.raises(ValueError, match="Missing required key in targets: 'val'"):
+        with pytest.raises(ValueError, match="Missing required keys in targets: 'test', 'val'"):
             CorpusSampler(invalid_targets, (500, 1000), default_genre_map) # type: ignore
 
 

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -242,7 +242,7 @@ class TestDatasetExtractorGetIdStream:
 		):
 			next(stream)
 
-class TestDatasetExtractorTitelExtraction:
+class TestDatasetExtractorTitleExtraction:
 	@pytest.mark.parametrize("text, expected, description", TITLE_TEST_CASES)
 	def test_extract_title_from_text(self, text, expected, description):
 		"""Test the extraction of a title from a raw text."""

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -92,7 +92,7 @@ class TestDatasetExtractorGetFullStream:
 		mock_interleave = mocker.patch("fetching.dataset_extractor.interleave_datasets")
 		extractor = DatasetExtractor(valid_multi_config)
 
-		stream = extractor.get_full_stream()
+		extractor.get_full_stream()
 
 		mock_load.assert_any_call(
 			"common-pile/project_gutenberg_filtered",
@@ -173,7 +173,7 @@ def test_real_huggingface_stream_interleaves_multiple_sources(monkeypatch):
 	"""
 	monkeypatch.setenv("SSL_CERT_FILE", certifi.where())
 	monkeypatch.delenv("HF_TOKEN", raising=False)
- 
+
 	extractor = DatasetExtractor(
 		[
 			{

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -27,6 +27,84 @@ def valid_multi_config():
 		},
 	]
 
+TITLE_TEST_CASES = [
+	# --- 1. The "Happy Paths" (Standard Formatting) ---
+	(
+		"# My Perfect Title\n\nThis is the first paragraph.", 
+		"My Perfect Title", 
+		"Standard Markdown H1"
+	),
+	(
+		"A Standard Plaintext Title\n\nAnd here is the body of the paper.", 
+		"A Standard Plaintext Title", 
+		"Standard plaintext first block"
+	),
+
+	# --- 2. Empty and Invalid Inputs ---
+	(None, "unknown", "None type input"),
+	("", "unknown", "Empty string"),
+	("    \n   \t  ", "unknown", "Whitespace-only string"),
+	(12345, "unknown", "Integer input (type safety)"),
+
+	# --- 3. Whitespace and Linebreak Chaos ---
+	(
+		"   #    Title   with   Crazy    Spaces    \n\nBody", 
+		"Title with Crazy Spaces", 
+		"Extreme internal and leading whitespace"
+	),
+	(
+		"# A Very Long\nTitle That Spans\nMultiple Lines\n\nFirst paragraph.", 
+		"A Very Long Title That Spans Multiple Lines", 
+		"Multiline markdown title with linebreaks inside the block"
+	),
+	(
+		"\n\n\n# Deeply Pushed Title\n\nBody text.", 
+		"Deeply Pushed Title", 
+		"Title preceded by multiple blank lines"
+	),
+
+	# --- 4. URL Stripping Triggers ---
+	(
+		"# Title With a Link http://arxiv.org/abs/123\n\nBody", 
+		"Title With a Link", 
+		"Standard HTTP link stripping"
+	),
+	(
+		"Another Title https://github.com/repo\n\nBody", 
+		"Another Title", 
+		"HTTPS link stripping (since 'http' is a substring)"
+	),
+	(
+		"http://example.com/no-title-just-link\n\nBody", 
+		"unknown", 
+		"First block is entirely a URL"
+	),
+
+	# --- Markdown Edge Cases ---
+	(
+		"## A Secondary Header\n\nBody", 
+		"A Secondary Header", 
+		"H2 header (strips both #s)"
+	),
+	(
+		"#Title Without Space\n\nBody", 
+		"Title Without Space", 
+		"Markdown H1 missing the space after the hash"
+	),
+
+	# --- 6. Current Heuristic Limitations ---
+	(
+		"Title Without Double Newlines\nThis is immediately followed by the abstract. No blank lines exist.\nWe just keep typing.", 
+		"Title Without Double Newlines This is immediately followed by the abstract. No blank lines exist. We just keep typing.", 
+		"No double newlines means the entire document is treated as the title block"
+	),
+	(
+		"# Understanding HTTP and FTP Protocols\n\nBody", 
+		"Understanding HTTP and FTP Protocols", 
+		"'HTTP' is uppercase, so .find('http') misses it (case-sensitivity)"
+	),
+]
+
 
 @pytest.fixture(autouse=True)
 def mock_token(monkeypatch):
@@ -163,6 +241,15 @@ class TestDatasetExtractorGetIdStream:
 			ValueError, match="No Project Gutenberg dataset found in config."
 		):
 			next(stream)
+   
+class TestDatasetExtractorTitelExtraction:
+	@pytest.mark.parametrize("text, expected, description", TITLE_TEST_CASES)
+	def test_extract_title_from_text(self, text, expected, description):
+		"""Test the extraction of a title from a raw text."""
+		extractor = DatasetExtractor([])
+		result = extractor._extract_title_from_text(text)
+		assert result == expected, f"Failed on: {description}"
+
 
 
 @pytest.mark.integration

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -1,96 +1,224 @@
 import pytest
 import logging
+import certifi
 from fetching.dataset_extractor import DatasetExtractor
+from datasets import IterableDataset
 
 
 @pytest.fixture
-def mock_token(mocker):
-    """Provide a mock Hugging Face token."""
-    mocker.patch("os.environ.get", return_value="hf_token")
-    return "hf_token"
+def valid_multi_config():
+	"""Provide a valid multi-dataset configuration array."""
+	return [
+		{
+			"path": "common-pile/project_gutenberg_filtered",
+			"type": "project_gutenberg",
+			"split_name": "train",
+			"column": "text",
+			"prefix": "pg",
+			"fallback_genres": ["Other / Uncategorized"],
+		},
+		{
+			"path": "common-pile/arxiv_papers_filtered",
+			"type": "technical",
+			"split_name": "train",
+			"column": "content",
+			"prefix": "arxiv",
+			"fallback_genres": ["Academic Papers"],
+		},
+	]
+
+
+@pytest.fixture(autouse=True)
+def mock_token(monkeypatch):
+	"""Provide a mock Hugging Face token."""
+	monkeypatch.setenv("HF_TOKEN", "fake_mock_token")
+	return "fake_mock_token"
 
 
 @pytest.fixture
 def mock_dataset_stream(mocker):
-    """Provide a mock dataset that handles select_columns and iteration."""
-    mock_ds = mocker.Mock()
-    mock_ds.select_columns.return_value = [
-        {"id": 101},
-        {"id": "202"},
-        {"id": 303},
-    ]
-    return mock_ds
+	"""Provide a mock dataset that handles select_columns and iteration."""
+	mock_ds = mocker.Mock()
+	mock_ds.select_columns.return_value = [
+		{"id": 101},
+		{"id": 202},
+		{"id": 303},
+	]
+	return mock_ds
 
 
-def loads_dataset(mock):
-    """Assert that load_dataset was called with the expected baseline arguments."""
-    mock.assert_called_once_with(
-        "test_dataset", split="train", streaming=True, token="hf_token"
-    )
+def loads_datasets(mock):
+	"""Assert that load_dataset was called with the expected baseline arguments."""
 
 
 class TestDatasetExtractorInit:
-    def test_finds_token_from_env(self, mock_token):
-        """Test token extraction from environment variables."""
-        extractor = DatasetExtractor("test")
-        assert extractor.dataset_name == "test", "Dataset name should be set"
-        assert extractor.token is not None, "Token should be found"
-        assert extractor.token == mock_token, "Token should be set"
+	def test_finds_token_from_env(self, mock_token, valid_multi_config):
+		"""Test token extraction from environment variables."""
+		extractor = DatasetExtractor(valid_multi_config)
+		assert getattr(extractor, "configs", None) == valid_multi_config, (
+			"Configs should be set to the provided array"
+		)
+		assert extractor.token is not None, "Token should be found"
+		assert extractor.token == mock_token, "Token should be set"
 
-    def test_default_logger(self, mocker):
-        """Test fallback logger initialization."""
-        extractor = DatasetExtractor("test")
-        assert extractor.logger is not None, "Logger should be initialized"
-        assert isinstance(extractor.logger.handlers[0], logging.NullHandler), (
-            "NullHandler should be added to logger"
-        )
+	def test_default_logger(self, valid_multi_config):
+		"""Test fallback logger initialization."""
+		extractor = DatasetExtractor(valid_multi_config)
+		assert extractor.logger is not None, "Logger should be initialized"
+		assert isinstance(extractor.logger.handlers[0], logging.NullHandler), (
+			"NullHandler should be added to logger"
+		)
 
-    def test_custom_logger(self, mocker):
-        """Test injected logger handling."""
-        mock_logger = mocker.Mock()
-        extractor = DatasetExtractor("test", logger=mock_logger)
-        assert extractor.logger is mock_logger, "Logger should be initialized"
-        mock_logger.addHandler.assert_not_called()
+	def test_custom_logger(self, mocker, valid_multi_config):
+		"""Test injected logger handling."""
+		mock_logger = mocker.Mock()
+		extractor = DatasetExtractor(valid_multi_config, logger=mock_logger)
+		assert extractor.logger is mock_logger, "Logger should be initialized"
+		mock_logger.addHandler.assert_not_called()
+
+	def fails_on_string_name(self):
+		"""Test that a string name fails to initialize."""
+		with pytest.raises(
+			TypeError, match="Must be a list of dictionaries"
+		) as excinfo:
+			DatasetExtractor("test")  # type: ignore
+		assert "Dataset must be a valid array of dictionaries" in str(excinfo.value)
 
 
 class TestDatasetExtractorGetFullStream:
-    def test_get_full_stream_calls_load_dataset(self, mocker, mock_token):
-        """Test standard dataset loading."""
-        mock_load = mocker.patch("fetching.dataset_extractor.load_dataset")
-        extractor = DatasetExtractor("test_dataset")
+	def test_get_full_stream_calls_load_dataset(self, mocker, valid_multi_config):
+		"""Test standard dataset loading."""
+		mock_load = mocker.patch("fetching.dataset_extractor.load_dataset")
+		mock_interleave = mocker.patch("fetching.dataset_extractor.interleave_datasets")
+		extractor = DatasetExtractor(valid_multi_config)
 
-        stream = extractor.get_full_stream()
+		stream = extractor.get_full_stream()
 
-        loads_dataset(mock_load)
-        assert stream == mock_load.return_value
+		mock_load.assert_any_call(
+			"common-pile/project_gutenberg_filtered",
+			split="train",
+			streaming=True,
+			token="fake_mock_token",
+		)
+		mock_load.assert_any_call(
+			"common-pile/arxiv_papers_filtered",
+			split="train",
+			streaming=True,
+			token="fake_mock_token",
+		)
 
-    def test_get_full_stream_logs_initialization(self, mocker, mock_token):
-        """Test logging during full stream initialization."""
-        mocker.patch("fetching.dataset_extractor.load_dataset")
-        mock_logger = mocker.Mock()
-        extractor = DatasetExtractor("test_dataset", logger=mock_logger)
+		mock_interleave.assert_called_once()
 
-        extractor.get_full_stream()
+	def test_get_full_stream_logs_initialization(self, mocker, valid_multi_config):
+		"""Test logging during full stream initialization."""
+		mocker.patch("fetching.dataset_extractor.load_dataset")
+		mocker.patch("fetching.dataset_extractor.interleave_datasets")
+		mock_logger = mocker.Mock()
+		extractor = DatasetExtractor(valid_multi_config, logger=mock_logger)
 
-        mock_logger.info.assert_called_once_with(
-            "Initializing full Hugging Face stream..."
-        )
+		extractor.get_full_stream()
+
+		mock_logger.info.assert_called_once_with(
+			"Initializing full Hugging Face stream..."
+		)
 
 
 class TestDatasetExtractorGetIdStream:
-    def test_get_id_stream_calls_load_dataset_and_yields_strings(
-        self, mocker, mock_token, mock_dataset_stream
-    ):
-        """Test that the stream properly filters columns and yields string IDs."""
-        mock_load = mocker.patch(
-            "fetching.dataset_extractor.load_dataset", return_value=mock_dataset_stream
-        )
-        extractor = DatasetExtractor("test_dataset")
+	def test_get_id_stream_calls_load_dataset_and_yields_strings(
+		self, mocker, mock_dataset_stream, valid_multi_config
+	):
+		"""Test that the stream properly filters columns and yields string IDs."""
+		mock_load = mocker.patch(
+			"fetching.dataset_extractor.load_dataset", return_value=mock_dataset_stream
+		)
+		extractor = DatasetExtractor(valid_multi_config)
 
-        stream_gen = extractor.get_id_stream()
-        results = list(stream_gen)
+		stream_gen = extractor.get_pg_id_stream()
+		results = list(stream_gen)
 
-        loads_dataset(mock_load)
-        mock_dataset_stream.select_columns.assert_called_once_with(["id"])
+		mock_load.assert_called_once_with(
+			"common-pile/project_gutenberg_filtered",
+			split="train",
+			streaming=True,
+			token="fake_mock_token",
+		)
+		mock_dataset_stream.select_columns.assert_called_once_with(["id"])
 
-        assert results == ["101", "202", "303"], "IDs should be yielded as strings"
+		assert results == ["101", "202", "303"], "IDs should be yielded as strings"
+
+	def test_get_pg_id_stream_no_pg(
+		self, mocker, mock_dataset_stream, valid_multi_config
+	):
+		"""Test that the stream properly filters columns and yields string IDs."""
+		mocker.patch(
+			"fetching.dataset_extractor.load_dataset", return_value=mock_dataset_stream
+		)
+		new_config = valid_multi_config.copy()
+		new_config[0]["type"] = "not_pg"
+		extractor = DatasetExtractor(new_config)
+
+		stream = extractor.get_pg_id_stream()
+
+		with pytest.raises(
+			ValueError, match="No Project Gutenberg dataset found in config."
+		):
+			next(stream)
+
+
+@pytest.mark.integration
+def test_real_huggingface_stream_interleaves_multiple_sources(monkeypatch):
+	"""Verify the extractor successfully interleaves multiple real datasets and normalizes schemas.
+
+	This test requires an active internet connection and valid Hugging Face access.
+	"""
+	monkeypatch.setenv("SSL_CERT_FILE", certifi.where())
+	monkeypatch.delenv("HF_TOKEN", raising=False)
+ 
+	extractor = DatasetExtractor(
+		[
+			{
+				"path": "common-pile/project_gutenberg_filtered",
+				"type": "project_gutenberg",
+				"split_name": "train",
+				"column": "text",
+				"prefix": "pg",
+				"fallback_genres": ["Other / Uncategorized"],
+			},
+			{
+				"path": "common-pile/arxiv_papers_filtered",
+				"type": "arxiv_papers",
+				"split_name": "train",
+				"column": "text",
+				"prefix": "arxiv",
+				"fallback_genres": ["Academic Papers"],
+			},
+		]
+	)
+
+	stream = extractor.get_full_stream()
+	assert isinstance(stream, IterableDataset)
+
+	stream_iter = iter(stream)
+
+	expected_keys = {
+		"id",
+		"text",
+		"source_name",
+		"prefix",
+		"source_type",
+		"fallback_genres",
+	}
+
+	found_prefixes = set()
+
+	for _ in range(4):
+		item = next(stream_iter)
+
+		assert set(item.keys()) == expected_keys
+		assert isinstance(item["text"], str)
+		assert isinstance(item["id"], str)
+
+		found_prefixes.add(item["prefix"])
+
+	assert "pg" in found_prefixes, "Stream did not yield any Gutenberg records."
+	assert "arxiv" in found_prefixes, "Stream did not yield any arXiv records."

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -30,13 +30,13 @@ def valid_multi_config():
 TITLE_TEST_CASES = [
 	# --- 1. The "Happy Paths" (Standard Formatting) ---
 	(
-		"# My Perfect Title\n\nThis is the first paragraph.", 
-		"My Perfect Title", 
+		"# My Perfect Title\n\nThis is the first paragraph.",
+		"My Perfect Title",
 		"Standard Markdown H1"
 	),
 	(
-		"A Standard Plaintext Title\n\nAnd here is the body of the paper.", 
-		"A Standard Plaintext Title", 
+		"A Standard Plaintext Title\n\nAnd here is the body of the paper.",
+		"A Standard Plaintext Title",
 		"Standard plaintext first block"
 	),
 
@@ -48,59 +48,59 @@ TITLE_TEST_CASES = [
 
 	# --- 3. Whitespace and Linebreak Chaos ---
 	(
-		"   #    Title   with   Crazy    Spaces    \n\nBody", 
-		"Title with Crazy Spaces", 
+		"   #    Title   with   Crazy    Spaces    \n\nBody",
+		"Title with Crazy Spaces",
 		"Extreme internal and leading whitespace"
 	),
 	(
-		"# A Very Long\nTitle That Spans\nMultiple Lines\n\nFirst paragraph.", 
-		"A Very Long Title That Spans Multiple Lines", 
+		"# A Very Long\nTitle That Spans\nMultiple Lines\n\nFirst paragraph.",
+		"A Very Long Title That Spans Multiple Lines",
 		"Multiline markdown title with linebreaks inside the block"
 	),
 	(
-		"\n\n\n# Deeply Pushed Title\n\nBody text.", 
-		"Deeply Pushed Title", 
+		"\n\n\n# Deeply Pushed Title\n\nBody text.",
+		"Deeply Pushed Title",
 		"Title preceded by multiple blank lines"
 	),
 
 	# --- 4. URL Stripping Triggers ---
 	(
-		"# Title With a Link http://arxiv.org/abs/123\n\nBody", 
-		"Title With a Link", 
+		"# Title With a Link http://arxiv.org/abs/123\n\nBody",
+		"Title With a Link",
 		"Standard HTTP link stripping"
 	),
 	(
-		"Another Title https://github.com/repo\n\nBody", 
-		"Another Title", 
+		"Another Title https://github.com/repo\n\nBody",
+		"Another Title",
 		"HTTPS link stripping (since 'http' is a substring)"
 	),
 	(
-		"http://example.com/no-title-just-link\n\nBody", 
-		"unknown", 
+		"http://example.com/no-title-just-link\n\nBody",
+		"unknown",
 		"First block is entirely a URL"
 	),
 
 	# --- Markdown Edge Cases ---
 	(
-		"## A Secondary Header\n\nBody", 
-		"A Secondary Header", 
+		"## A Secondary Header\n\nBody",
+		"A Secondary Header",
 		"H2 header (strips both #s)"
 	),
 	(
-		"#Title Without Space\n\nBody", 
-		"Title Without Space", 
+		"#Title Without Space\n\nBody",
+		"Title Without Space",
 		"Markdown H1 missing the space after the hash"
 	),
 
 	# --- 6. Current Heuristic Limitations ---
 	(
-		"Title Without Double Newlines\nThis is immediately followed by the abstract. No blank lines exist.\nWe just keep typing.", 
-		"Title Without Double Newlines This is immediately followed by the abstract. No blank lines exist. We just keep typing.", 
+		"Title Without Double Newlines\nThis is immediately followed by the abstract. No blank lines exist.\nWe just keep typing.",
+		"Title Without Double Newlines This is immediately followed by the abstract. No blank lines exist. We just keep typing.",
 		"No double newlines means the entire document is treated as the title block"
 	),
 	(
-		"# Understanding HTTP and FTP Protocols\n\nBody", 
-		"Understanding HTTP and FTP Protocols", 
+		"# Understanding HTTP and FTP Protocols\n\nBody",
+		"Understanding HTTP and FTP Protocols",
 		"'HTTP' is uppercase, so .find('http') misses it (case-sensitivity)"
 	),
 ]
@@ -241,7 +241,7 @@ class TestDatasetExtractorGetIdStream:
 			ValueError, match="No Project Gutenberg dataset found in config."
 		):
 			next(stream)
-   
+
 class TestDatasetExtractorTitelExtraction:
 	@pytest.mark.parametrize("text, expected, description", TITLE_TEST_CASES)
 	def test_extract_title_from_text(self, text, expected, description):

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -3,6 +3,8 @@ import logging
 import certifi
 from fetching.dataset_extractor import DatasetExtractor
 from datasets import IterableDataset
+from typing import Any
+from dataclasses import dataclass
 
 
 @pytest.fixture
@@ -27,81 +29,77 @@ def valid_multi_config():
 		},
 	]
 
+
 TITLE_TEST_CASES = [
 	# --- 1. The "Happy Paths" (Standard Formatting) ---
 	(
 		"# My Perfect Title\n\nThis is the first paragraph.",
 		"My Perfect Title",
-		"Standard Markdown H1"
+		"Standard Markdown H1",
 	),
 	(
 		"A Standard Plaintext Title\n\nAnd here is the body of the paper.",
 		"A Standard Plaintext Title",
-		"Standard plaintext first block"
+		"Standard plaintext first block",
 	),
-
 	# --- 2. Empty and Invalid Inputs ---
 	(None, "unknown", "None type input"),
 	("", "unknown", "Empty string"),
 	("    \n   \t  ", "unknown", "Whitespace-only string"),
 	(12345, "unknown", "Integer input (type safety)"),
-
 	# --- 3. Whitespace and Linebreak Chaos ---
 	(
 		"   #    Title   with   Crazy    Spaces    \n\nBody",
 		"Title with Crazy Spaces",
-		"Extreme internal and leading whitespace"
+		"Extreme internal and leading whitespace",
 	),
 	(
 		"# A Very Long\nTitle That Spans\nMultiple Lines\n\nFirst paragraph.",
 		"A Very Long Title That Spans Multiple Lines",
-		"Multiline markdown title with linebreaks inside the block"
+		"Multiline markdown title with linebreaks inside the block",
 	),
 	(
 		"\n\n\n# Deeply Pushed Title\n\nBody text.",
 		"Deeply Pushed Title",
-		"Title preceded by multiple blank lines"
+		"Title preceded by multiple blank lines",
 	),
-
 	# --- 4. URL Stripping Triggers ---
 	(
 		"# Title With a Link http://arxiv.org/abs/123\n\nBody",
 		"Title With a Link",
-		"Standard HTTP link stripping"
+		"Standard HTTP link stripping",
 	),
 	(
 		"Another Title https://github.com/repo\n\nBody",
 		"Another Title",
-		"HTTPS link stripping (since 'http' is a substring)"
+		"HTTPS link stripping (since 'http' is a substring)",
 	),
 	(
 		"http://example.com/no-title-just-link\n\nBody",
 		"unknown",
-		"First block is entirely a URL"
+		"First block is entirely a URL",
 	),
-
 	# --- Markdown Edge Cases ---
 	(
 		"## A Secondary Header\n\nBody",
 		"A Secondary Header",
-		"H2 header (strips both #s)"
+		"H2 header (strips both #s)",
 	),
 	(
 		"#Title Without Space\n\nBody",
 		"Title Without Space",
-		"Markdown H1 missing the space after the hash"
+		"Markdown H1 missing the space after the hash",
 	),
-
 	# --- 6. Current Heuristic Limitations ---
 	(
 		"Title Without Double Newlines\nThis is immediately followed by the abstract. No blank lines exist.\nWe just keep typing.",
 		"Title Without Double Newlines This is immediately followed by the abstract. No blank lines exist. We just keep typing.",
-		"No double newlines means the entire document is treated as the title block"
+		"No double newlines means the entire document is treated as the title block",
 	),
 	(
 		"# Understanding HTTP and FTP Protocols\n\nBody",
 		"Understanding HTTP and FTP Protocols",
-		"'HTTP' is uppercase, so .find('http') misses it (case-sensitivity)"
+		"'HTTP' is uppercase, so .find('http') misses it (case-sensitivity)",
 	),
 ]
 
@@ -242,6 +240,76 @@ class TestDatasetExtractorGetIdStream:
 		):
 			next(stream)
 
+
+@dataclass
+class NormalizeTestCase:
+	"""Encapsulates parameters for testing record normalization."""
+
+	desc: str
+	record: dict[str, Any]
+	expected_source_name: str
+	expected_id: str
+
+
+NORMALIZE_CASES = [
+	NormalizeTestCase(
+		desc="Valid: Extracts title from standard metadata dict",
+		record={
+			"id": 123,  # Integer ID should be cast to string
+			"text": "Some document text.",
+			"metadata": {"title": "The Great Paper"},
+		},
+		expected_source_name="The Great Paper",
+		expected_id="123",
+	),
+	NormalizeTestCase(
+		desc="Fallback: Extracts title from text if metadata title is missing",
+		record={
+			"id": "abc-456",
+			"text": "# Header Title\n\nSome document text.",
+			"metadata": {},
+		},
+		expected_source_name="Header Title",
+		expected_id="abc-456",
+	),
+	NormalizeTestCase(
+		desc="Fallback: Extracts title from text if metadata is not a dict",
+		record={
+			"id": "def-789",
+			"text": "Plaintext Title\n\nSome document text.",
+			"metadata": "corrupted_string_metadata",
+		},
+		expected_source_name="Plaintext Title",
+		expected_id="def-789",
+	),
+	NormalizeTestCase(
+		desc="Edge Case: Missing ID and missing metadata entirely",
+		record={"text": "Emergency Title\n\nSome document text."},
+		expected_source_name="Emergency Title",
+		expected_id="unknown",
+	),
+]
+
+
+@pytest.mark.parametrize("case", NORMALIZE_CASES, ids=lambda c: c.desc)
+def test_normalize_record_logic(case: NormalizeTestCase):
+	"""Test the normalization mapping logic across various metadata states."""
+
+	# Empty config is fine since we are just testing the isolated method
+	extractor = DatasetExtractor([])
+
+	result = extractor._normalize_record(
+		x=case.record, p="test_prefix", t="test_type", fg=["Test Genre"]
+	)
+
+	assert result["source_name"] == case.expected_source_name
+	assert result["id"] == case.expected_id
+	assert result["text"] == case.record["text"]
+	assert result["prefix"] == "test_prefix"
+	assert result["source_type"] == "test_type"
+	assert result["fallback_genres"] == ["Test Genre"]
+
+
 class TestDatasetExtractorTitleExtraction:
 	@pytest.mark.parametrize("text, expected, description", TITLE_TEST_CASES)
 	def test_extract_title_from_text(self, text, expected, description):
@@ -249,7 +317,6 @@ class TestDatasetExtractorTitleExtraction:
 		extractor = DatasetExtractor([])
 		result = extractor._extract_title_from_text(text)
 		assert result == expected, f"Failed on: {description}"
-
 
 
 @pytest.mark.integration

--- a/test/genre_mapping/test_genre_mapper.py
+++ b/test/genre_mapping/test_genre_mapper.py
@@ -51,7 +51,7 @@ class TestGenreMapperInit:
 class TestGenreMapperRun:
     def test_run_orchestrates_streaming_pipeline(self, mocker, mock_dependencies):
         """Test the streaming batch logic and intermediate checkpoint saving."""
-        mock_dependencies["extractor"].get_id_stream.return_value = iter(
+        mock_dependencies["extractor"].get_pg_id_stream.return_value = iter(
             ["1001", "1002", "1003"]
         )
 
@@ -89,7 +89,7 @@ class TestGenreMapperRun:
 
     def test_run_skips_existing_cached_ids(self, mocker, mock_dependencies):
         """Test that the cache prevents duplicate API calls for known books."""
-        mock_dependencies["extractor"].get_id_stream.return_value = iter(
+        mock_dependencies["extractor"].get_pg_id_stream.return_value = iter(
             ["1001", "1002"]
         )
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -54,7 +54,7 @@ def test_generate_cipher_fails_cipher(mocker, book_text):
 
 	with pytest.raises(ValueError) as excinfo:
 		generate_cipher(1000, 5000, "test_cipher.json", 10)
-	assert "must include a non-empty, lowercase alphabetic string with no spaces in the text field." in str(excinfo.value)
+	assert "Plaintext must be a lowercase alphabetic string with no spaces" in str(excinfo.value)
 
 	# Clean up
 	import os
@@ -89,7 +89,7 @@ def test_generate_monoalphabetic_cipher_fails(mocker, book_text):
 
 	with pytest.raises(ValueError) as excinfo:
 		generate_monoalphabetic_cipher(1000, 5000, "test_mono_cipher.json")
-	assert " must include a non-empty, lowercase alphabetic string with no spaces in the text field." in str(excinfo.value)
+	assert "Plaintext must be a lowercase alphabetic string with no spaces" in str(excinfo.value)
 
 	# Clean up
 	import os

--- a/test/utils/test_validators.py
+++ b/test/utils/test_validators.py
@@ -243,6 +243,13 @@ VALIDATE_TYPED_DICT_CASES = [
 		expected_context=pytest.raises(ValueError),
 		match="All elements in",
 	),
+	TypeTestCase(
+		desc="Invalid: Not a dictionary",
+		value="not a dict",
+		type_hint=DummyConfig,
+		expected_context=pytest.raises(TypeError),
+		match="must be of type dict",
+	),
 ]
 
 

--- a/test/utils/test_validators.py
+++ b/test/utils/test_validators.py
@@ -1,132 +1,255 @@
 import pytest
+from dataclasses import dataclass
+from typing import Any, TypedDict
+from contextlib import nullcontext as does_not_raise
 
 from utils.validators import (
 	in_range,
 	strongly_typed_optional,
 	lower_case_no_spaces_alpha_string,
-	is_alpha_lowercase_no_spaces,
+	validate_typed_dict,
 )
 
 
-class TestInRangeValidator:
-	@pytest.fixture
-	def validator(self):
-		return in_range(10, 20)
+@dataclass
+class RangeTestCase:
+	"""Encapsulates parameters for in_range validation tests."""
 
-	def test_value_within_range(self, validator):
-		validator(15, name="test_param", type_hint=int)
-
-	def test_value_equal_to_min(self, validator):
-		validator(10, name="test_param", type_hint=int)
-
-	def test_value_equal_to_max(self, validator):
-		validator(20, name="test_param", type_hint=int)
-
-	def test_value_below_min(self, validator):
-		with pytest.raises(ValueError) as excinfo:
-			validator(5, name="test_param", type_hint=int)
-		assert "Parameter `test_param` must be between 10 and 20." in str(excinfo.value)
-
-	def test_value_above_max(self, validator):
-		with pytest.raises(ValueError) as excinfo:
-			validator(25, name="test_param", type_hint=int)
-		assert "Parameter `test_param` must be between 10 and 20." in str(excinfo.value)
-
-	def test_non_integer_value(self, validator):
-		# Non-integer values should be ignored by the validator
-		validator("string_value", name="test_param", type_hint=str)
+	desc: str
+	value: Any
+	min_val: int
+	max_val: int
+	expected_context: Any
+	match: str | None = None
 
 
-class TestStronglyTypedOptionalValidator:
-	def test_value_is_none(self):
-		# None should be accepted
-		strongly_typed_optional(None, name="optional_param", type_hint=int)
+@dataclass
+class TypeTestCase:
+	"""Encapsulates parameters for type validation tests."""
 
-	def test_value_of_expected_type(self):
-		strongly_typed_optional(42, name="optional_param", type_hint=int)
-
-	def test_illegal_type_value(self):
-		with pytest.raises(TypeError) as excinfo:
-			strongly_typed_optional("not an int", name="optional_param", type_hint=int)
-		assert "Parameter `optional_param` must be of type int or None." in str(
-			excinfo.value
-		)
-
-	def test_value_of_union_type(self):
-		type_hint = int | str | None
-		strongly_typed_optional(42, name="optional_param", type_hint=type_hint)  # type: ignore
-		strongly_typed_optional("a string", name="optional_param", type_hint=type_hint)  # type: ignore
-
-	def test_value_of_unexpected_union_type(self):
-		type_hint = int | str | None
-		with pytest.raises(TypeError) as excinfo:
-			strongly_typed_optional(3.14, name="optional_param", type_hint=type_hint)  # type: ignore
-		assert "Parameter `optional_param` must be of type int, str, or None." in str(
-			excinfo.value
-		)
+	desc: str
+	value: Any
+	type_hint: Any
+	expected_context: Any
+	match: str | None = None
 
 
-class TestLowerCaseNoSpacesAlphaStringValidator:
-	def test_valid_string(self):
+@dataclass
+class ValueTestCase:
+	"""Encapsulates parameters for generic value validation tests."""
+
+	desc: str
+	value: Any
+	expected_context: Any
+	match: str | None = None
+
+
+class DummyTextStream(TypedDict):
+	"""Mock TypedDict to simulate TextStream annotations."""
+
+	id: str
+	text: str
+	source_name: str
+
+
+class DummyConfig(TypedDict):
+	"""Mock TypedDict to test validate_typed_dict."""
+
+	name: str
+	items: list[int]
+
+
+IN_RANGE_CASES = [
+	RangeTestCase(
+		desc="Valid: Inside range",
+		value=5,
+		min_val=1,
+		max_val=10,
+		expected_context=does_not_raise(),
+	),
+	RangeTestCase(
+		desc="Valid: Exact minimum boundary",
+		value=1,
+		min_val=1,
+		max_val=10,
+		expected_context=does_not_raise(),
+	),
+	RangeTestCase(
+		desc="Valid: Exact maximum boundary",
+		value=10,
+		min_val=1,
+		max_val=10,
+		expected_context=does_not_raise(),
+	),
+	RangeTestCase(
+		desc="Invalid: Below minimum",
+		value=0,
+		min_val=1,
+		max_val=10,
+		expected_context=pytest.raises(ValueError),
+		match="must be between",
+	),
+	RangeTestCase(
+		desc="Invalid: Above maximum",
+		value=11,
+		min_val=1,
+		max_val=10,
+		expected_context=pytest.raises(ValueError),
+		match="must be between",
+	),
+	RangeTestCase(
+		desc="Ignored: Non-integer types safely return early",
+		value="5",
+		min_val=1,
+		max_val=10,
+		expected_context=does_not_raise(),
+	),
+]
+
+
+@pytest.mark.parametrize("case", IN_RANGE_CASES, ids=lambda c: c.desc)
+def test_in_range(case: RangeTestCase):
+	"""Test the integer range boundary validator using a single case object.
+
+	The target value must be passed positionally, while the parameter name
+	is supplied as a keyword argument to satisfy the @validator wrapper.
+	"""
+	validator_func = in_range(case.min_val, case.max_val)
+	with case.expected_context as exc_info:
+		validator_func(case.value, name="test_param", type_hint=int)
+	if case.match and exc_info:
+		assert case.match in str(exc_info.value)
+
+
+STRONGLY_TYPED_OPTIONAL_CASES = [
+	TypeTestCase(
+		desc="Valid: None passes for any expected type",
+		value=None,
+		type_hint=int,
+		expected_context=does_not_raise(),
+	),
+	TypeTestCase(
+		desc="Valid: Exact type match",
+		value=5,
+		type_hint=int,
+		expected_context=does_not_raise(),
+	),
+	TypeTestCase(
+		desc="Valid: Matches one of UnionType options",
+		value=5,
+		type_hint=str | int,
+		expected_context=does_not_raise(),
+	),
+	TypeTestCase(
+		desc="Invalid: Type mismatch",
+		value="5",
+		type_hint=int,
+		expected_context=pytest.raises(TypeError),
+		match="must be of type int",
+	),
+	TypeTestCase(
+		desc="Invalid: UnionType mismatch",
+		value=[1, 2],
+		type_hint=str | int,
+		expected_context=pytest.raises(TypeError),
+		match="must be of type str, int",
+	),
+]
+
+
+@pytest.mark.parametrize("case", STRONGLY_TYPED_OPTIONAL_CASES, ids=lambda c: c.desc)
+def test_strongly_typed_optional(case: TypeTestCase):
+	"""Test the strongly typed optional parameter validator using a single case object."""
+	with case.expected_context as exc_info:
+		strongly_typed_optional(case.value, name="test_param", type_hint=case.type_hint)
+	if case.match and exc_info:
+		assert case.match in str(exc_info.value)
+
+
+LOWER_CASE_ALPHA_CASES = [
+	TypeTestCase(
+		desc="Valid: Lowercase alpha string without spaces",
+		value="helloworld",
+		type_hint=str,
+		expected_context=does_not_raise(),
+	),
+	TypeTestCase(
+		desc="Invalid: Not a string",
+		value=123,
+		type_hint=str,
+		expected_context=pytest.raises(TypeError),
+		match="must be of type str",
+	),
+	TypeTestCase(
+		desc="Invalid: Empty string",
+		value="",
+		type_hint=str,
+		expected_context=pytest.raises(ValueError),
+		match="non-blank",
+	),
+	TypeTestCase(
+		desc="Invalid: Contains spaces",
+		value="hello world",
+		type_hint=str,
+		expected_context=pytest.raises(ValueError),
+		match="lowercase alphabetic",
+	),
+	TypeTestCase(
+		desc="Invalid: Contains uppercase characters",
+		value="HelloWorld",
+		type_hint=str,
+		expected_context=pytest.raises(ValueError),
+		match="lowercase alphabetic",
+	),
+]
+
+
+@pytest.mark.parametrize("case", LOWER_CASE_ALPHA_CASES, ids=lambda c: c.desc)
+def test_lower_case_no_spaces_alpha_string(case: TypeTestCase):
+	"""Test the strictly constrained string validator using a single case object."""
+	with case.expected_context as exc_info:
 		lower_case_no_spaces_alpha_string(
-			"validstring", name="test_param", type_hint=str
+			case.value, name="test_param", type_hint=case.type_hint
 		)
-
-	def test_string_with_spaces(self):
-		with pytest.raises(ValueError) as excinfo:
-			lower_case_no_spaces_alpha_string(
-				"invalid string", name="test_param", type_hint=str
-			)
-		assert (
-			"Parameter `test_param` must be a lowercase alphabetic string with no spaces."
-			in str(excinfo.value)
-		)
-
-	def test_string_with_uppercase(self):
-		with pytest.raises(ValueError) as excinfo:
-			lower_case_no_spaces_alpha_string(
-				"InvalidString", name="test_param", type_hint=str
-			)
-		assert (
-			"Parameter `test_param` must be a lowercase alphabetic string with no spaces."
-			in str(excinfo.value)
-		)
-
-	def test_string_with_non_alpha(self):
-		with pytest.raises(ValueError) as excinfo:
-			lower_case_no_spaces_alpha_string(
-				"invalid123", name="test_param", type_hint=str
-			)
-		assert (
-			"Parameter `test_param` must be a lowercase alphabetic string with no spaces."
-			in str(excinfo.value)
-		)
-
-	def test_non_string_value(self):
-		with pytest.raises(TypeError) as excinfo:
-			lower_case_no_spaces_alpha_string(12345, name="test_param", type_hint=str)
-		assert "Parameter `test_param` must be of type str." in str(excinfo.value)
-
-	def test_empty_string(self):
-		with pytest.raises(ValueError) as excinfo:
-			lower_case_no_spaces_alpha_string("", name="test_param", type_hint=str)
-		assert "Parameter `test_param` must be a non-blank string." in str(
-			excinfo.value
-		)
+	if case.match and exc_info:
+		assert case.match in str(exc_info.value)
 
 
-class TestIsAlphaLowercaseNoSpaces:
-	def test_valid_string(self):
-		assert is_alpha_lowercase_no_spaces("validstring") is True
+VALIDATE_TYPED_DICT_CASES = [
+	TypeTestCase(
+		desc="Valid: Dictionary perfectly matches TypedDict schema",
+		value={"name": "test", "items": [1, 2, 3]},
+		type_hint=DummyConfig,
+		expected_context=does_not_raise(),
+	),
+	TypeTestCase(
+		desc="Invalid: Missing key",
+		value={"items": [1, 2, 3]},
+		type_hint=DummyConfig,
+		expected_context=pytest.raises(ValueError),
+		match="Missing required key",
+	),
+	TypeTestCase(
+		desc="Invalid: Root key type mismatch",
+		value={"name": 123, "items": [1, 2, 3]},
+		type_hint=DummyConfig,
+		expected_context=pytest.raises(ValueError),
+		match="Invalid type for key 'name'",
+	),
+	TypeTestCase(
+		desc="Invalid: Generic list sub-type mismatch",
+		value={"name": "test", "items": [1, "two", 3]},
+		type_hint=DummyConfig,
+		expected_context=pytest.raises(ValueError),
+		match="All elements in",
+	),
+]
 
-	def test_string_with_spaces(self):
-		assert is_alpha_lowercase_no_spaces("invalid string") is False
 
-	def test_string_with_uppercase(self):
-		assert is_alpha_lowercase_no_spaces("InvalidString") is False
-
-	def test_string_with_non_alpha(self):
-		assert is_alpha_lowercase_no_spaces("invalid123") is False
-
-	def test_empty_string(self):
-		assert is_alpha_lowercase_no_spaces("") is False
+@pytest.mark.parametrize("case", VALIDATE_TYPED_DICT_CASES, ids=lambda c: c.desc)
+def test_validate_typed_dict(case: TypeTestCase):
+	"""Test the recursive TypedDict schema validator using a single case object."""
+	with case.expected_context as exc_info:
+		validate_typed_dict(case.value, name="test_dict", type_hint=case.type_hint)
+	if case.match and exc_info:
+		assert case.match in str(exc_info.value)


### PR DESCRIPTION
## Overview
This PR introduces a significant refactor across the dataset extraction pipeline, parameter validation, and the testing suite. It transitions the extraction logic from a single-dataset model to a multi-dataset interleaving architecture, replaces ad-hoc validation with robust `TypedDict` schemas, and modernizes the testing suite using dataclass-driven parameterized tests.

## Key Changes

### Dataset Extraction & Processing
* **Multi-Dataset Interleaving:** Upgraded `DatasetExtractor` to accept an array of `DatasetConfig` objects, allowing it to seamlessly interleave multiple Hugging Face streams (e.g., Project Gutenberg and arXiv) into a unified pipeline.
* **Smart Title Extraction:** Implemented robust regex-based title extraction (`_extract_title_from_text`) to fallback on Markdown headers or the first text block when standard metadata is missing.
* **Record Normalization:** Added `_normalize_record` to standardize incoming data schemas across differing datasets before interleaving.
* **Targeted ID Streams:** Updated the ID stream method to specifically target Gutenberg texts (`get_pg_id_stream()`) to prevent pipeline breaks.

### Validation & Type Safety
* **`TypedDict` Validation:** Replaced specific object validators (`validate_text_obj`, `validate_targets`) with a unified, recursive `validate_typed_dict` function capable of strictly validating nested structures and types against `TypedDict` definitions.
* **Strict Schemas:** Introduced typed dictionaries (`DatasetConfig`, `Targets`, `DummyTextStream`) to strictly enforce expected data shapes throughout the application.
* **Inline Validation:** Shifted specific string validations (like empty checks and lowercase/no-spaces rules) directly into class initializers (`HomophonicCipher`, `MonoalphabeticCipher`) for tighter scoping. 

### Test Suite Modernization
* **Dataclass-Driven Testing:** Refactored multiple test files (`test_validators.py`, `test_dataset_extractor.py`, `test_cipher.py`) to use dataclasses (`RangeTestCase`, `TypeTestCase`, `NormalizeTestCase`) alongside `@pytest.mark.parametrize`. This drastically reduces boilerplate and makes adding new edge cases trivial.
* **Integration Markers:** Added a custom `integration` pytest marker to isolate heavy, network-dependent tests (like real Hugging Face streaming).

### CI & Tooling
* **Workflow Optimization:** Excluded integration tests (`-m "not integration"`) from the standard GitHub Actions `.github/workflows/test.yml` workflow to significantly speed up the primary CI checks.
* **Pytest Config:** Registered the custom `integration` marker in `pyproject.toml` to suppress Pytest warnings.