### PR TITLE
feat: safe id prefixing

### DIFF
--- a/src/fetching/dataset_extractor.py
+++ b/src/fetching/dataset_extractor.py
@@ -69,7 +69,8 @@ class DatasetExtractor:
 			self.logger.addHandler(logging.NullHandler())
 			self.logger.setLevel(logging.CRITICAL)
 
-	def _extract_title_from_text(self, text: str) -> str:
+	@staticmethod
+	def _extract_title_from_text(text: str) -> str:
 		"""Extract a prospective title from the beginning of a raw document.
 
 		Targets Markdown headers or the first distinct text block, normalizing
@@ -101,7 +102,8 @@ class DatasetExtractor:
 
 		return clean_title or "unknown"
 
-	def _normalize_record(self, x: dict, p: str, t: str, fg: list[str]) -> dict:
+	@staticmethod
+	def _normalize_record(x: dict, p: str, t: str, fg: list[str]) -> dict:
 		"""Normalize individual records and safely map metadata."""
 		metadata = x.get("metadata", {})
 		source_name = "unknown"
@@ -109,16 +111,15 @@ class DatasetExtractor:
 			source_name = metadata.get("title", "unknown")
 
 		if source_name == "unknown":
-			source_name = self._extract_title_from_text(x["text"])
+			source_name = DatasetExtractor._extract_title_from_text(x["text"])
 
 		return {
-			"id": str(x.get("id", "unknown")),
-			"text": x["text"],
-			"source_name": source_name,
-			"prefix": p,
-			"source_type": t,
-			"fallback_genres": fg,
-		}
+            "id": f"{p}:{str(x.get('id', 'unknown'))}",
+            "text": x["text"],
+            "source_name": source_name,
+            "source_type": t,
+            "fallback_genres": fg,
+        }
 
 	def get_full_stream(self) -> IterableDataset:
 		"""Get the full Hugging Face stream.
@@ -148,7 +149,7 @@ class DatasetExtractor:
 			fallback_genres = config.get("fallback_genres", ["Other / Uncategorized"])
 
 			ds = ds.map(
-				self._normalize_record,
+				DatasetExtractor._normalize_record,
 				fn_kwargs={"p": prefix, "t": source_type, "fg": fallback_genres},
 			)
 
@@ -156,7 +157,6 @@ class DatasetExtractor:
 				"id",
 				"text",
 				"source_name",
-				"prefix",
 				"source_type",
 				"fallback_genres",
 			]

--- a/src/gen_training.py
+++ b/src/gen_training.py
@@ -4,7 +4,7 @@ from cipher_generation.cipher_manager import CipherManager
 from typing import Iterator
 
 from fetching.dataset_extractor import DatasetExtractor
-from fetching.corpus_sampler import CorpusSampler
+from fetching.corpus_sampler import CorpusSampler, Targets
 from utils.genres import load_existing_genre_map
 from utils.text_splits import randomize_stream, TextStream
 from utils.constants import (
@@ -12,12 +12,12 @@ from utils.constants import (
 	NUM_VALIDATION_CIPHERS,
 	NUM_TEST_CIPHERS,
 	GENRE_MAP_PATH,
-	DATASET_NAME,
+	DATASETS,
 )
 
 
 def get_text_stream(
-	targets: dict[str, int],
+	targets: Targets,
 	len_bounds: tuple[int, int] = (4000, 10000),
 	extractor: DatasetExtractor | None = None,
 ) -> Iterator[tuple[str, TextStream]]:
@@ -33,7 +33,7 @@ def get_text_stream(
 
 	"""
 	if extractor is None:
-		extractor = DatasetExtractor(DATASET_NAME)
+		extractor = DatasetExtractor(DATASETS)
 
 	genre_map = load_existing_genre_map(GENRE_MAP_PATH, None)
 	full_stream = randomize_stream(extractor.get_full_stream())
@@ -72,11 +72,13 @@ if __name__ == "__main__":
 		load_folder_ids()
 	)
 
-	targets = {
-		"train": NUM_TRAINING_CIPHERS,
-		"val": NUM_VALIDATION_CIPHERS,
-		"test": NUM_TEST_CIPHERS,
-	}
+	targets = Targets(
+		{
+			"train": NUM_TRAINING_CIPHERS,
+			"val": NUM_VALIDATION_CIPHERS,
+			"test": NUM_TEST_CIPHERS,
+		},
+	)
 
 	text_stream = get_text_stream(targets=targets)
 

--- a/src/map_genres.py
+++ b/src/map_genres.py
@@ -2,14 +2,14 @@ from utils.logging import get_logger
 from genre_mapping.gutendex_client import GutendexClient
 from fetching.dataset_extractor import DatasetExtractor
 from genre_mapping.taxonomy_mapper import TaxonomyMapper
-from utils.constants import DATASET_NAME, GENRE_MAP_PATH
+from utils.constants import DATASETS, GENRE_MAP_PATH
 from genre_mapping.genre_mapper import GenreMapper
 
 
 if __name__ == "__main__":
 	logger = get_logger("GenreMapper")
 
-	extractor = DatasetExtractor(DATASET_NAME, logger=logger)
+	extractor = DatasetExtractor(DATASETS, logger=logger)
 	api_client = GutendexClient(logger=logger)
 	mapper = TaxonomyMapper()
 	genre_mapper = GenreMapper(extractor, api_client, mapper, logger=logger)

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -50,7 +50,24 @@ BOOK_IDS_VALIDATION = [
 ]
 
 TOTAL_BOOKS = 55_454
-DATASET_NAME = "common-pile/project_gutenberg_filtered"
+DATASETS = [
+	{
+		"path": "common-pile/project_gutenberg_filtered",
+		"type": "project_gutenberg",
+		"split_name": "train",
+		"column": "text",
+		"prefix": "pg",
+		"fallback_genres": ["Other / Uncategorized"],
+	},
+	{
+		"path": "common-pile/arxiv_papers_filtered",
+		"type": "technical",
+		"split_name": "train",
+		"column": "content",
+		"prefix": "arxiv",
+		"fallback_genres": ["Academic Papers"],
+	}
+]
 
 DEFAULT_TAXONOMY = {
 		"Sci-Fi & Fantasy": ["science fiction", "fantasy", "science-fiction"],

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -1,6 +1,7 @@
 """Constants for the cipher generation."""
 
 from pathlib import Path
+from fetching.dataset_extractor import DatasetConfig
 
 MIN_DIFFICULTY = 4
 MAX_DIFFICULTY = 30
@@ -50,7 +51,7 @@ BOOK_IDS_VALIDATION = [
 ]
 
 TOTAL_BOOKS = 55_454
-DATASETS = [
+DATASETS: list[DatasetConfig] = [
 	{
 		"path": "common-pile/project_gutenberg_filtered",
 		"type": "project_gutenberg",
@@ -66,7 +67,7 @@ DATASETS = [
 		"column": "content",
 		"prefix": "arxiv",
 		"fallback_genres": ["Academic Papers"],
-	}
+	},
 ]
 
 DEFAULT_TAXONOMY = {

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -62,7 +62,7 @@ DATASETS: list[DatasetConfig] = [
 	},
 	{
 		"path": "common-pile/arxiv_papers_filtered",
-		"type": "technical",
+		"type": "arxiv_papers",
 		"split_name": "train",
 		"column": "content",
 		"prefix": "arxiv",

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -30,80 +30,6 @@ def valid_multi_config():
 	]
 
 
-TITLE_TEST_CASES = [
-	# --- 1. The "Happy Paths" (Standard Formatting) ---
-	(
-		"# My Perfect Title\n\nThis is the first paragraph.",
-		"My Perfect Title",
-		"Standard Markdown H1",
-	),
-	(
-		"A Standard Plaintext Title\n\nAnd here is the body of the paper.",
-		"A Standard Plaintext Title",
-		"Standard plaintext first block",
-	),
-	# --- 2. Empty and Invalid Inputs ---
-	(None, "unknown", "None type input"),
-	("", "unknown", "Empty string"),
-	("    \n   \t  ", "unknown", "Whitespace-only string"),
-	(12345, "unknown", "Integer input (type safety)"),
-	# --- 3. Whitespace and Linebreak Chaos ---
-	(
-		"   #    Title   with   Crazy    Spaces    \n\nBody",
-		"Title with Crazy Spaces",
-		"Extreme internal and leading whitespace",
-	),
-	(
-		"# A Very Long\nTitle That Spans\nMultiple Lines\n\nFirst paragraph.",
-		"A Very Long Title That Spans Multiple Lines",
-		"Multiline markdown title with linebreaks inside the block",
-	),
-	(
-		"\n\n\n# Deeply Pushed Title\n\nBody text.",
-		"Deeply Pushed Title",
-		"Title preceded by multiple blank lines",
-	),
-	# --- 4. URL Stripping Triggers ---
-	(
-		"# Title With a Link http://arxiv.org/abs/123\n\nBody",
-		"Title With a Link",
-		"Standard HTTP link stripping",
-	),
-	(
-		"Another Title https://github.com/repo\n\nBody",
-		"Another Title",
-		"HTTPS link stripping (since 'http' is a substring)",
-	),
-	(
-		"http://example.com/no-title-just-link\n\nBody",
-		"unknown",
-		"First block is entirely a URL",
-	),
-	# --- Markdown Edge Cases ---
-	(
-		"## A Secondary Header\n\nBody",
-		"A Secondary Header",
-		"H2 header (strips both #s)",
-	),
-	(
-		"#Title Without Space\n\nBody",
-		"Title Without Space",
-		"Markdown H1 missing the space after the hash",
-	),
-	# --- 6. Current Heuristic Limitations ---
-	(
-		"Title Without Double Newlines\nThis is immediately followed by the abstract. No blank lines exist.\nWe just keep typing.",
-		"Title Without Double Newlines This is immediately followed by the abstract. No blank lines exist. We just keep typing.",
-		"No double newlines means the entire document is treated as the title block",
-	),
-	(
-		"# Understanding HTTP and FTP Protocols\n\nBody",
-		"Understanding HTTP and FTP Protocols",
-		"'HTTP' is uppercase, so .find('http') misses it (case-sensitivity)",
-	),
-]
-
-
 @pytest.fixture(autouse=True)
 def mock_token(monkeypatch):
 	"""Provide a mock Hugging Face token."""
@@ -297,26 +223,113 @@ def test_normalize_record_logic(case: NormalizeTestCase):
 
 	# Empty config is fine since we are just testing the isolated method
 	extractor = DatasetExtractor([])
+	prefix = "tp"
+	source_type = "test_type"
+	fallback_genres = ["Test Genre"]
 
 	result = extractor._normalize_record(
-		x=case.record, p="test_prefix", t="test_type", fg=["Test Genre"]
+		x=case.record, p=prefix, t=source_type, fg=fallback_genres
 	)
 
 	assert result["source_name"] == case.expected_source_name
-	assert result["id"] == case.expected_id
+	assert result["id"] == f"{prefix}:{case.expected_id}"
 	assert result["text"] == case.record["text"]
-	assert result["prefix"] == "test_prefix"
-	assert result["source_type"] == "test_type"
-	assert result["fallback_genres"] == ["Test Genre"]
+	assert result["source_type"] == source_type
+	assert result["fallback_genres"] == fallback_genres
+
+
+@dataclass
+class TitleTestCase:
+	"""Encapsulates parameters for testing title extraction."""
+
+	text: str
+	expected: str
+	desc: str
+
+
+TITLE_TEST_CASES = [
+	# --- 1. The "Happy Paths" (Standard Formatting) ---
+	TitleTestCase(
+		"# My Perfect Title\n\nThis is the first paragraph.",
+		"My Perfect Title",
+		"Standard Markdown H1",
+	),
+	TitleTestCase(
+		"A Standard Plaintext Title\n\nAnd here is the body of the paper.",
+		"A Standard Plaintext Title",
+		"Standard plaintext first block",
+	),
+	# --- 2. Empty and Invalid Inputs ---
+	TitleTestCase(None, "unknown", "None type input"),  # type: ignore
+	TitleTestCase("", "unknown", "Empty string"),
+	TitleTestCase("    \n   \t  ", "unknown", "Whitespace-only string"),
+	TitleTestCase(12345, "unknown", "Integer input (type safety)"),  # type: ignore
+	# --- 3. Whitespace and Linebreak Chaos ---
+	TitleTestCase(
+		"   #    Title   with   Crazy    Spaces    \n\nBody",
+		"Title with Crazy Spaces",
+		"Extreme internal and leading whitespace",
+	),
+	TitleTestCase(
+		"# A Very Long\nTitle That Spans\nMultiple Lines\n\nFirst paragraph.",
+		"A Very Long Title That Spans Multiple Lines",
+		"Multiline markdown title with linebreaks inside block",
+	),
+	TitleTestCase(
+		"\n\n\n# Deeply Pushed Title\n\nBody text.",
+		"Deeply Pushed Title",
+		"Title preceded by multiple blank lines",
+	),
+	# --- 4. URL Stripping Triggers ---
+	TitleTestCase(
+		"# Title With a Link http://arxiv.org/abs/123\n\nBody",
+		"Title With a Link",
+		"Standard HTTP link stripping",
+	),
+	TitleTestCase(
+		"Another Title https://github.com/repo\n\nBody",
+		"Another Title",
+		"HTTPS link stripping (since 'http' is a substring)",
+	),
+	TitleTestCase(
+		"http://example.com/no-title-just-link\n\nBody",
+		"unknown",
+		"First block is entirely a URL",
+	),
+	# --- Markdown Edge Cases ---
+	TitleTestCase(
+		"## A Secondary Header\n\nBody",
+		"A Secondary Header",
+		"H2 header (strips both #s)",
+	),
+	TitleTestCase(
+		"#Title Without Space\n\nBody",
+		"Title Without Space",
+		"Markdown H1 missing the space after the hash",
+	),
+	# --- 6. Current Heuristic Limitations ---
+	TitleTestCase(
+		"Title Without Double Newlines\nThis is immediately followed by the abstract. No blank lines exist.\nWe just keep typing.",
+		"Title Without Double Newlines This is immediately followed by the abstract. No blank lines exist. We just keep typing.",
+		"No double newlines -> entire document is treated as the title block",
+	),
+	TitleTestCase(
+		"# Understanding HTTP and FTP Protocols\n\nBody",
+		"Understanding HTTP and FTP Protocols",
+		"'HTTP' is uppercase, so .find('http') misses it (case-sensitivity)",
+	),
+]
 
 
 class TestDatasetExtractorTitleExtraction:
-	@pytest.mark.parametrize("text, expected, description", TITLE_TEST_CASES)
-	def test_extract_title_from_text(self, text, expected, description):
+	@pytest.mark.parametrize(
+		"case", TITLE_TEST_CASES, ids=lambda c: c.desc
+	)
+	def test_extract_title_from_text(self, case):
 		"""Test the extraction of a title from a raw text."""
 		extractor = DatasetExtractor([])
-		result = extractor._extract_title_from_text(text)
-		assert result == expected, f"Failed on: {description}"
+		result = extractor._extract_title_from_text(case.text)
+		assert result == case.expected, f"Failed on: {case.description}"
 
 
 @pytest.mark.integration
@@ -358,12 +371,11 @@ def test_real_huggingface_stream_interleaves_multiple_sources(monkeypatch):
 		"id",
 		"text",
 		"source_name",
-		"prefix",
 		"source_type",
 		"fallback_genres",
 	}
 
-	found_prefixes = set()
+	found_source_types = set()
 
 	for _ in range(4):
 		item = next(stream_iter)
@@ -372,7 +384,11 @@ def test_real_huggingface_stream_interleaves_multiple_sources(monkeypatch):
 		assert isinstance(item["text"], str)
 		assert isinstance(item["id"], str)
 
-		found_prefixes.add(item["prefix"])
+		found_source_types.add(item["source_type"])
 
-	assert "pg" in found_prefixes, "Stream did not yield any Gutenberg records."
-	assert "arxiv" in found_prefixes, "Stream did not yield any arXiv records."
+	assert "project_gutenberg" in found_source_types, (
+		"Stream did not yield any Gutenberg records."
+	)
+	assert "arxiv_papers" in found_source_types, (
+		"Stream did not yield any arXiv records."
+	)


### PR DESCRIPTION
## Overview
This PR transitions the pipeline from a single dataset configuration to supporting multiple datasets. It introduces the arXiv dataset alongside Project Gutenberg and refactors the `DatasetExtractor` to cleanly handle merging records. It also improves type safety and test structure.

## Key Changes
* **Multi-Dataset Support:** Replaced the single `DATASET_NAME` with a `DATASETS` list in `constants.py`, adding configuration for `arxiv_papers_filtered`.
* **ID Namespace Prefixing:** Removed the standalone `prefix` field from records and integrated it directly into the `id` field (e.g., `prefix:id`). This prevents ID collisions when interleaving records from multiple datasets and simplifies the schema.
* **Extractor Refactoring:** Converted `_extract_title_from_text` and `_normalize_record` to `@staticmethod`s to better encapsulate stateless logic.
* **Type Safety:** Implemented the `Targets` type in `gen_training.py` for stricter type checking during text stream generation.
* **Test Suite Updates:** Refactored `TITLE_TEST_CASES` to use a `TitleTestCase` dataclass for better readability and updated integration tests to assert against `source_type` instead of `prefix`.