### PR TITLE
Refactor corpus sampling with Book TypedDict and centralized genre resolution

### DIFF
--- a/src/fetching/corpus_sampler.py
+++ b/src/fetching/corpus_sampler.py
@@ -7,11 +7,14 @@ from utils.text_splits import (
 	get_book_chunks,
 	get_actual_take,
 	get_usable_text,
+	get_source_genres,
 	TextStream,
+	Book,
 )
 
 from utils.validators import validate_typed_dict
 from parameter_validator import parameter_validator
+
 
 class Targets(TypedDict):
 	"""A typed dictionary for target counts."""
@@ -19,6 +22,7 @@ class Targets(TypedDict):
 	train: int
 	val: int
 	test: int
+
 
 class CorpusSampler:
 	"""Manages the stateful extraction of texts across dataset splits."""
@@ -71,7 +75,7 @@ class CorpusSampler:
 
 			yield from self._process_book(book, split)
 
-	def _process_book(self, book: dict, split: str) -> Iterator[tuple[str, TextStream]]:
+	def _process_book(self, book: Book, split: str) -> Iterator[tuple[str, TextStream]]:
 		"""Handle the extraction and debt calculation for a single book."""
 		raw_text = book["text"]
 		usable_text = get_usable_text(raw_text, self.len_bounds)
@@ -99,7 +103,7 @@ class CorpusSampler:
 					"source_id": book.get("id", "unknown"),
 					"source_name": book.get("metadata", {}).get("title", "unknown"),
 					"length": len(chunk),
-					"genres": self.genre_map.get(str(book.get("id")), []),
+					"genres": get_source_genres(book, self.genre_map),
 				},
 			)
 			self.counts[split] += 1

--- a/src/utils/text_splits.py
+++ b/src/utils/text_splits.py
@@ -6,6 +6,16 @@ from datasets.iterable_dataset import IterableDataset
 from utils.formatting import format_text, clean_spaces
 
 
+class Book(TypedDict):
+	"""A typed dictionary for book metadata."""
+
+	id: str
+	text: str
+	source_name: str
+	source_type: str
+	fallback_genres: list[str]
+
+
 class TextStream(TypedDict):
 	"""A text stream object.
 
@@ -211,3 +221,12 @@ def get_usable_text(raw_text: str, len_bounds: tuple[int, int]) -> str:
 	else:
 		usable_text = raw_text[start_trim : total_len - end_trim]
 	return usable_text
+
+
+def get_source_genres(book: Book, genre_map: dict[str, list[str]]) -> list[str]:
+	"""Get the source genres for a book."""
+	if book.get("source_type") == "project_gutenberg":
+		id = book.get("id").removeprefix("pg:")
+		return genre_map.get(id, book.get("fallback_genres", []))
+	else:
+		return book.get("fallback_genres", [])

--- a/src/utils/text_splits.py
+++ b/src/utils/text_splits.py
@@ -224,7 +224,16 @@ def get_usable_text(raw_text: str, len_bounds: tuple[int, int]) -> str:
 
 
 def get_source_genres(book: Book, genre_map: dict[str, list[str]]) -> list[str]:
-	"""Get the source genres for a book."""
+	"""Get the source genres for a book.
+
+	Args:
+		book (Book): The book to get the genres for.
+		genre_map (dict[str, list[str]]): The genre map to use for filtering.
+
+	Returns:
+		list[str]: The source genres for the book.
+
+	"""
 	if book.get("source_type") == "project_gutenberg":
 		id = book.get("id").removeprefix("pg:")
 		return genre_map.get(id, book.get("fallback_genres", []))

--- a/test/fetching/test_corpus_sampler.py
+++ b/test/fetching/test_corpus_sampler.py
@@ -1,169 +1,186 @@
 import pytest
 from fetching.corpus_sampler import CorpusSampler
+from utils.text_splits import Book
 
 
 @pytest.fixture
 def default_targets():
-    """Provides a valid targets dictionary."""
-    return {"train": 100, "val": 10, "test": 10}
+	"""Provides a valid targets dictionary."""
+	return {"train": 100, "val": 10, "test": 10}
 
 
 @pytest.fixture
 def default_genre_map():
-    """Provides a sample genre mapping."""
-    return {"1": ["Fiction"], "2": ["Science Fiction"]}
+	"""Provides a sample genre mapping."""
+	return {"1": ["Fiction"], "2": ["Science Fiction"]}
 
 
 @pytest.fixture
 def mock_constants(mocker):
-    """Mocks global constants to ensure deterministic tests."""
-    mocker.patch("fetching.corpus_sampler.TOTAL_BOOKS", 100)
-    mocker.patch("fetching.corpus_sampler.BOOK_IDS_VALIDATION", ["999"])
+	"""Mocks global constants to ensure deterministic tests."""
+	mocker.patch("fetching.corpus_sampler.TOTAL_BOOKS", 100)
+	mocker.patch("fetching.corpus_sampler.BOOK_IDS_VALIDATION", ["999"])
 
 
 class TestCorpusSamplerInit:
-    def test_init_calculates_means_correctly(
-        self, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that the sampler properly calculates mathematical targets upon initialization."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+	def test_init_calculates_means_correctly(
+		self, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that the sampler properly calculates mathematical targets upon initialization."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
 
-        expected_train_mean = 100 / (100 * 0.98)
-        expected_val_mean = 10 / (100 * 0.01)
+		expected_train_mean = 100 / (100 * 0.98)
+		expected_val_mean = 10 / (100 * 0.01)
 
-        assert sampler.means["train"] == expected_train_mean
-        assert sampler.means["val"] == expected_val_mean
-        assert sampler.targets == default_targets
-        assert sampler.len_bounds == (500, 1000)
+		assert sampler.means["train"] == expected_train_mean
+		assert sampler.means["val"] == expected_val_mean
+		assert sampler.targets == default_targets
+		assert sampler.len_bounds == (500, 1000)
 
-    def test_init_raises_value_error_on_invalid_targets(self, default_genre_map):
-        """Test that the parameter validator intercepts incorrect dictionary keys."""
-        invalid_targets = {"train": 100, "validation": 10}
+	def test_init_raises_value_error_on_invalid_targets(self, default_genre_map):
+		"""Test that the parameter validator intercepts incorrect dictionary keys."""
+		invalid_targets = {"train": 100, "validation": 10}
 
-        with pytest.raises(ValueError, match="Missing required keys in targets: 'test', 'val'"):
-            CorpusSampler(invalid_targets, (500, 1000), default_genre_map) # type: ignore
+		with pytest.raises(
+			ValueError, match="Missing required keys in targets: 'test', 'val'"
+		):
+			CorpusSampler(invalid_targets, (500, 1000), default_genre_map)  # type: ignore
 
 
 class TestCorpusSamplerIsComplete:
-    def test_is_complete_returns_false_initially(
-        self, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that a fresh sampler is not marked as complete."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        assert not sampler.is_complete()
+	def test_is_complete_returns_false_initially(
+		self, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that a fresh sampler is not marked as complete."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		assert not sampler.is_complete()
 
-    def test_is_complete_returns_true_when_quotas_met(
-        self, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that the sampler correctly identifies when all targets are exactly met."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        sampler.counts = {"train": 100, "val": 10, "test": 10}
-        assert sampler.is_complete()
+	def test_is_complete_returns_true_when_quotas_met(
+		self, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that the sampler correctly identifies when all targets are exactly met."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		sampler.counts = {"train": 100, "val": 10, "test": 10}
+		assert sampler.is_complete()
 
-    def test_is_complete_handles_overfulfillment(
-        self, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that exceeding the target counts still correctly triggers completion."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        sampler.counts = {"train": 150, "val": 12, "test": 11}
-        assert sampler.is_complete()
+	def test_is_complete_handles_overfulfillment(
+		self, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that exceeding the target counts still correctly triggers completion."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		sampler.counts = {"train": 150, "val": 12, "test": 11}
+		assert sampler.is_complete()
 
 
 class TestCorpusSamplerGenerateStream:
-    def test_generate_stream_stops_when_complete(
-        self, mocker, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that iteration halts immediately if quotas are full."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        mocker.patch.object(sampler, "is_complete", return_value=True)
-        mock_process = mocker.patch.object(sampler, "_process_book")
+	def test_generate_stream_stops_when_complete(
+		self, mocker, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that iteration halts immediately if quotas are full."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		mocker.patch.object(sampler, "is_complete", return_value=True)
+		mock_process = mocker.patch.object(sampler, "_process_book")
 
-        dummy_stream = [{"id": "1", "text": "dummy"}]
-        results = list(sampler.generate_stream(dummy_stream))
+		dummy_stream = [{"id": "1", "text": "dummy"}]
+		results = list(sampler.generate_stream(dummy_stream))
 
-        assert len(results) == 0
-        mock_process.assert_not_called()
+		assert len(results) == 0
+		mock_process.assert_not_called()
 
-    def test_generate_stream_skips_validation_ids(
-        self, mocker, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that the sampler explicitly ignores books in the validation blocklist."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        mock_process = mocker.patch.object(sampler, "_process_book")
+	def test_generate_stream_skips_validation_ids(
+		self, mocker, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that the sampler explicitly ignores books in the validation blocklist."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		mock_process = mocker.patch.object(sampler, "_process_book")
 
-        dummy_stream = [{"id": "999", "text": "dummy"}]
-        list(sampler.generate_stream(dummy_stream))
+		dummy_stream = [{"id": "999", "text": "dummy"}]
+		list(sampler.generate_stream(dummy_stream))
 
-        mock_process.assert_not_called()
+		mock_process.assert_not_called()
 
-    def test_generate_stream_skips_fulfilled_splits(
-        self, mocker, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that books assigned to an already-full split are discarded."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        sampler.counts["val"] = 10
+	def test_generate_stream_skips_fulfilled_splits(
+		self, mocker, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that books assigned to an already-full split are discarded."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		sampler.counts["val"] = 10
 
-        mocker.patch("fetching.corpus_sampler.get_split", return_value="val")
-        mock_process = mocker.patch.object(sampler, "_process_book")
+		mocker.patch("fetching.corpus_sampler.get_split", return_value="val")
+		mock_process = mocker.patch.object(sampler, "_process_book")
 
-        dummy_stream = [{"id": "1", "text": "dummy"}]
-        list(sampler.generate_stream(dummy_stream))
+		dummy_stream = [{"id": "1", "text": "dummy"}]
+		list(sampler.generate_stream(dummy_stream))
 
-        mock_process.assert_not_called()
+		mock_process.assert_not_called()
 
-    def test_generate_stream_yields_from_process_book(
-        self, mocker, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that valid books are correctly passed to the processing method."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        mocker.patch("fetching.corpus_sampler.get_split", return_value="train")
+	def test_generate_stream_yields_from_process_book(
+		self, mocker, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that valid books are correctly passed to the processing method."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		mocker.patch("fetching.corpus_sampler.get_split", return_value="train")
 
-        expected_yield = ("train", {"text": "chunk"})
-        mocker.patch.object(sampler, "_process_book", return_value=iter([expected_yield]))
+		expected_yield = ("train", {"text": "chunk"})
+		mocker.patch.object(
+			sampler, "_process_book", return_value=iter([expected_yield])
+		)
 
-        dummy_stream = [{"id": "1", "text": "dummy"}]
-        results = list(sampler.generate_stream(dummy_stream))
+		dummy_stream = [{"id": "1", "text": "dummy"}]
+		results = list(sampler.generate_stream(dummy_stream))
 
-        assert results == [expected_yield]
+		assert results == [expected_yield]
 
 
 class TestCorpusSamplerProcessBook:
-    def test_process_book_zero_capacity_returns_early(
-        self, mocker, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that short texts yielding zero capacity do not alter the stream or state."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
-        mocker.patch("fetching.corpus_sampler.get_usable_text", return_value="short")
-        mocker.patch("fetching.corpus_sampler.get_actual_take", return_value=0)
+	def test_process_book_zero_capacity_returns_early(
+		self, mocker, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that short texts yielding zero capacity do not alter the stream or state."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+		mocker.patch("fetching.corpus_sampler.get_usable_text", return_value="short")
+		mocker.patch("fetching.corpus_sampler.get_actual_take", return_value=0)
 
-        book = {"id": "1", "text": "short", "metadata": {}}
-        results = list(sampler._process_book(book, "train"))
+		book = Book(
+			id="1",
+			text="short",
+			source_name="Test Title",
+			source_type="project_gutenberg",
+			fallback_genres=["Other / Uncategorized"],
+		)
+		results = list(sampler._process_book(book, "train"))
 
-        assert len(results) == 0
+		assert len(results) == 0
 
-    def test_process_book_yields_chunks_and_updates_state(
-        self, mocker, mock_constants, default_targets, default_genre_map
-    ):
-        """Test that the sampler successfully yields formatted chunks and updates its tracking variables."""
-        sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
+	def test_process_book_yields_chunks_and_updates_state(
+		self, mocker, mock_constants, default_targets, default_genre_map
+	):
+		"""Test that the sampler successfully yields formatted chunks and updates its tracking variables."""
+		sampler = CorpusSampler(default_targets, (500, 1000), default_genre_map)
 
-        mocker.patch(
-            "fetching.corpus_sampler.get_usable_text", return_value="long valid text"
-        )
-        mocker.patch("fetching.corpus_sampler.get_actual_take", return_value=2)
+		mocker.patch(
+			"fetching.corpus_sampler.get_usable_text", return_value="long valid text"
+		)
+		mocker.patch("fetching.corpus_sampler.get_actual_take", return_value=2)
 
-        mock_chunks = [("chunk1", "chunk1_bound"), ("chunk2", "chunk2_bound")]
-        mocker.patch(
-            "fetching.corpus_sampler.get_book_chunks", return_value=iter(mock_chunks)
-        )
+		mock_chunks = [("chunk1", "chunk1_bound"), ("chunk2", "chunk2_bound")]
+		mocker.patch(
+			"fetching.corpus_sampler.get_book_chunks", return_value=iter(mock_chunks)
+		)
 
-        book = {"id": "1", "text": "long valid text", "metadata": {"title": "Test Title"}}
+		book = Book(
+			id="1",
+			text="long valid text",
+			source_name="Test Title",
+			source_type="project_gutenberg",
+			fallback_genres=["Other / Uncategorized"],
+		)
 
-        initial_debt = sampler.debts["train"]
-        results = list(sampler._process_book(book, "train"))
+		initial_debt = sampler.debts["train"]
+		results = list(sampler._process_book(book, "train"))
 
-        assert len(results) == 2
-        assert results[0][1]["text"] == "chunk1"
-        assert results[0][1]["genres"] == ["Fiction"]
-        assert sampler.counts["train"] == 2
-        assert sampler.debts["train"] == initial_debt + sampler.means["train"] - 2
+		assert len(results) == 2
+		assert results[0][1]["text"] == "chunk1"
+		assert results[0][1]["genres"] == ["Fiction"]
+		assert sampler.counts["train"] == 2
+		assert sampler.debts["train"] == initial_debt + sampler.means["train"] - 2

--- a/test/fetching/test_dataset_extractor.py
+++ b/test/fetching/test_dataset_extractor.py
@@ -384,6 +384,11 @@ def test_real_huggingface_stream_interleaves_multiple_sources(monkeypatch):
 		assert isinstance(item["text"], str)
 		assert isinstance(item["id"], str)
 
+		if item["source_type"] == "project_gutenberg":
+			assert item["id"].startswith("pg:")
+		elif item["source_type"] == "arxiv_papers":
+			assert item["id"].startswith("arxiv:")
+
 		found_source_types.add(item["source_type"])
 
 	assert "project_gutenberg" in found_source_types, (

--- a/test/utils/test_text_splits.py
+++ b/test/utils/test_text_splits.py
@@ -1,133 +1,222 @@
 import pytest
+from dataclasses import dataclass
 from utils.text_splits import (
-    find_boundaries,
-    find_spaceless_target_index,
-    extract_random_chunk,
-    get_split,
-    get_book_chunks,
-    get_usable_text,
-    get_actual_take,
-    randomize_stream,
+	find_boundaries,
+	find_spaceless_target_index,
+	extract_random_chunk,
+	get_split,
+	get_book_chunks,
+	get_usable_text,
+	get_actual_take,
+	randomize_stream,
+	get_source_genres,
+	Book,
 )
 
 # --- Fixtures ---
 
+
 @pytest.fixture
 def mock_book_stream():
-    return [
-        {
-            "id": "1",
-            "text": "Book One content " * 500,
-            "metadata": {"title": "Book One"},
-        },
-        {
-            "id": "2",
-            "text": "Book Two content " * 500,
-            "metadata": {"title": "Book Two"},
-        },
-        {
-            "id": "3",
-            "text": "Book Three content " * 500,
-            "metadata": {"title": "Book Three"},
-        },
-    ]
+	return [
+		{
+			"id": "1",
+			"text": "Book One content " * 500,
+			"metadata": {"title": "Book One"},
+		},
+		{
+			"id": "2",
+			"text": "Book Two content " * 500,
+			"metadata": {"title": "Book Two"},
+		},
+		{
+			"id": "3",
+			"text": "Book Three content " * 500,
+			"metadata": {"title": "Book Three"},
+		},
+	]
+
 
 # --- Helper Function Tests ---
 
+
 class TestTextHelpers:
-    def test_find_boundaries_standard(self, sample_text_with_spaces):
-        start, end = find_boundaries(sample_text_with_spaces, 10, 11)
-        assert sample_text_with_spaces[start:end] == "test plaintext"
+	def test_find_boundaries_standard(self, sample_text_with_spaces):
+		start, end = find_boundaries(sample_text_with_spaces, 10, 11)
+		assert sample_text_with_spaces[start:end] == "test plaintext"
 
-    def test_find_spaceless_target_index(self):
-        text = "a b c d e"
-        assert find_spaceless_target_index(text, 3) == 4
-        assert find_spaceless_target_index(text, 10) == len(text)
+	def test_find_spaceless_target_index(self):
+		text = "a b c d e"
+		assert find_spaceless_target_index(text, 3) == 4
+		assert find_spaceless_target_index(text, 10) == len(text)
 
-    def test_get_split(self):
-        assert get_split(0) == "val"
-        assert get_split(1) == "test"
-        assert get_split(2) == "train"
-        assert get_split(100) == "val"
+	def test_get_split(self):
+		assert get_split(0) == "val"
+		assert get_split(1) == "test"
+		assert get_split(2) == "train"
+		assert get_split(100) == "val"
 
-    def test_get_actual_take_logic(self):
-        debts = {"train": 10.5}
-        assert get_actual_take("train", debts, 5) == 5
-        assert get_actual_take("train", debts, 20) == 10
-        assert get_actual_take("train", debts, 0) == 0
+	def test_get_actual_take_logic(self):
+		debts = {"train": 10.5}
+		assert get_actual_take("train", debts, 5) == 5
+		assert get_actual_take("train", debts, 20) == 10
+		assert get_actual_take("train", debts, 0) == 0
 
-    def test_get_usable_text_trimming(self):
-        raw = "A" * 100_000
-        usable = get_usable_text(raw, (4000, 10000))
-        assert len(usable) == 97_000
+	def test_get_usable_text_trimming(self):
+		raw = "A" * 100_000
+		usable = get_usable_text(raw, (4000, 10000))
+		assert len(usable) == 97_000
 
-    def test_get_usable_text_short_book(self):
-        raw = "Short book content"
-        usable = get_usable_text(raw, (4000, 10000))
-        assert usable == raw
+	def test_get_usable_text_short_book(self):
+		raw = "Short book content"
+		usable = get_usable_text(raw, (4000, 10000))
+		assert usable == raw
 
-    def test_randomize_stream(self, mocker):
-        mock_stream = mocker.Mock()
-        randomize_stream(mock_stream)
-        mock_stream.shuffle.assert_called_once_with(seed=42, buffer_size=100)
+	def test_randomize_stream(self, mocker):
+		mock_stream = mocker.Mock()
+		randomize_stream(mock_stream)
+		mock_stream.shuffle.assert_called_once_with(seed=42, buffer_size=100)
+
 
 # --- Core Logic Tests ---
 
+
 class TestChunkExtraction:
-    def test_extract_random_chunk_logic_flow(self, mocker):
-        text = "wordone wordtwo wordthree wordfour"
-        mocker.patch("random.randint", side_effect=[12, 0, 0, 0])
-        mocker.patch("utils.text_splits.format_text", side_effect=lambda x: x)
+	def test_extract_random_chunk_logic_flow(self, mocker):
+		text = "wordone wordtwo wordthree wordfour"
+		mocker.patch("random.randint", side_effect=[12, 0, 0, 0])
+		mocker.patch("utils.text_splits.format_text", side_effect=lambda x: x)
 
-        chunk, bounded_chunk = extract_random_chunk(text, 0, len(text), (10, 20))
+		chunk, bounded_chunk = extract_random_chunk(text, 0, len(text), (10, 20))
 
-        assert " " not in chunk
-        assert chunk == "wordonewordtwo"
-        assert bounded_chunk == "wordone_wordtwo"
+		assert " " not in chunk
+		assert chunk == "wordonewordtwo"
+		assert bounded_chunk == "wordone_wordtwo"
 
-    def test_get_book_chunks_filters_length(self, mocker, sample_text, sample_text_with_boundaries):
-        min_bound = int(len(sample_text) - 0.05 * len(sample_text))
+	def test_get_book_chunks_filters_length(
+		self, mocker, sample_text, sample_text_with_boundaries
+	):
+		min_bound = int(len(sample_text) - 0.05 * len(sample_text))
 
-        mocker.patch(
-            "utils.text_splits.extract_random_chunk",
-            side_effect=[(sample_text, sample_text_with_boundaries), (sample_text, sample_text_with_boundaries)],
-        )
+		mocker.patch(
+			"utils.text_splits.extract_random_chunk",
+			side_effect=[
+				(sample_text, sample_text_with_boundaries),
+				(sample_text, sample_text_with_boundaries),
+			],
+		)
 
-        chunks = list(
-            get_book_chunks("dummy text", actual_take=2, len_bounds=(min_bound, 2000))
-        )
+		chunks = list(
+			get_book_chunks("dummy text", actual_take=2, len_bounds=(min_bound, 2000))
+		)
 
-        assert len(chunks) == 2
-        assert chunks[0][0] == sample_text
-        assert chunks[0][1] == sample_text_with_boundaries
-        assert chunks[1][0] == sample_text
-        assert chunks[1][1] == sample_text_with_boundaries
+		assert len(chunks) == 2
+		assert chunks[0][0] == sample_text
+		assert chunks[0][1] == sample_text_with_boundaries
+		assert chunks[1][0] == sample_text
+		assert chunks[1][1] == sample_text_with_boundaries
 
-    def test_get_book_chunks_drops_oversized(self, mocker):
-        max_bound = 50
-        long_chunk = "a" * 100
-        mocker.patch(
-            "utils.text_splits.extract_random_chunk",
-            return_value=(long_chunk, long_chunk),
-        )
+	def test_get_book_chunks_drops_oversized(self, mocker):
+		max_bound = 50
+		long_chunk = "a" * 100
+		mocker.patch(
+			"utils.text_splits.extract_random_chunk",
+			return_value=(long_chunk, long_chunk),
+		)
 
-        chunks = list(get_book_chunks("text", 1, (10, max_bound)))
+		chunks = list(get_book_chunks("text", 1, (10, max_bound)))
 
-        assert len(chunks) == 0
+		assert len(chunks) == 0
 
-    def test_extract_random_chunk_reaches_end_of_text(self, mocker):
-        short_text = "This is very short."
-        mocker.patch("random.randint", side_effect=[100, 0, 0])
-        mocker.patch("utils.text_splits.format_text", side_effect=lambda x: x)
+	def test_extract_random_chunk_reaches_end_of_text(self, mocker):
+		short_text = "This is very short."
+		mocker.patch("random.randint", side_effect=[100, 0, 0])
+		mocker.patch("utils.text_splits.format_text", side_effect=lambda x: x)
 
-        chunk = extract_random_chunk(short_text, 0, 10, (5, 150))
-        assert len(chunk) > 0
+		chunk = extract_random_chunk(short_text, 0, 10, (5, 150))
+		assert len(chunk) > 0
 
-    def test_extract_random_chunk_too_small_returns_immediately(self, mocker):
-        text = "tiny"
-        mocker.patch("random.randint", side_effect=[10, 0, 0])
-        mocker.patch("utils.text_splits.format_text", side_effect=lambda x: x)
+	def test_extract_random_chunk_too_small_returns_immediately(self, mocker):
+		text = "tiny"
+		mocker.patch("random.randint", side_effect=[10, 0, 0])
+		mocker.patch("utils.text_splits.format_text", side_effect=lambda x: x)
 
-        chunk, chunk_bounded = extract_random_chunk(text, 0, 5, (5, 15))
-        assert chunk == "tiny"
-        assert chunk_bounded == "tiny"
+		chunk, chunk_bounded = extract_random_chunk(text, 0, 5, (5, 15))
+		assert chunk == "tiny"
+		assert chunk_bounded == "tiny"
+
+
+class TestGetSourceGenres:
+	@dataclass
+	class GetSourceTestCase:
+		book: Book
+		genre_map: dict[str, list[str]]
+		expected_genres: list[str]
+		desc: str
+
+	TEST_CASES_GET_SOURCES = [
+		GetSourceTestCase(
+			book={
+				"id": "pg:123",
+				"source_type": "project_gutenberg",
+				"fallback_genres": ["Fiction"],
+				"text": "...",
+				"source_name": "Gutenberg",
+			},
+			genre_map={"123": ["Sci-Fi", "Adventure"]},
+			expected_genres=["Sci-Fi", "Adventure"],
+			desc="Gutenberg source: ID found in map",
+		),
+		GetSourceTestCase(
+			book={
+				"id": "pg:456",
+				"source_type": "project_gutenberg",
+				"fallback_genres": ["Classic"],
+				"text": "...",
+				"source_name": "Gutenberg",
+			},
+			genre_map={"123": ["Sci-Fi"]},
+			expected_genres=["Classic"],
+			desc="Gutenberg source: ID NOT in map (uses fallback)",
+		),
+		GetSourceTestCase(
+			book={
+				"id": "other:789",
+				"source_type": "local_library",
+				"fallback_genres": ["History"],
+				"text": "...",
+				"source_name": "Local",
+			},
+			genre_map={"789": ["Biography"]},
+			expected_genres=["History"],
+			desc="Non-Gutenberg source: ignores map, uses fallback",
+		),
+		GetSourceTestCase(
+			book={
+				"id": "pg:999",
+				"source_type": "project_gutenberg",
+				"fallback_genres": [],
+				"text": "...",
+				"source_name": "Gutenberg",
+			},
+			genre_map={},
+			expected_genres=[],
+			desc="Gutenberg source: empty map and empty fallback",
+		),
+		GetSourceTestCase(
+			book={
+				"id": "123",  # No prefix to remove
+				"source_type": "project_gutenberg",
+				"fallback_genres": ["Drama"],
+				"text": "...",
+				"source_name": "Gutenberg",
+			},
+			genre_map={"123": ["Drama (Mapped)"]},
+			expected_genres=["Drama (Mapped)"],
+			desc="Gutenberg source: ID exists without prefix",
+		),
+	]
+
+	@pytest.mark.parametrize("case", TEST_CASES_GET_SOURCES, ids=lambda c: c.desc)
+	def test_get_source_genres_returns_fallback(self, case: GetSourceTestCase):
+		assert get_source_genres(case.book, case.genre_map) == case.expected_genres


### PR DESCRIPTION
## Overview
This PR improves type safety within the fetching pipeline by introducing a `Book` TypedDict and centralizing genre resolution logic. It also standardizes indentation across the affected source and test files.

## Changes

### src/utils/text_splits.py
- Introduced the `Book` TypedDict to define expected metadata fields (id, text, source_name, source_type, fallback_genres).
- Added `get_source_genres` utility to handle prefix stripping for Project Gutenberg IDs and provide a fallback mechanism for genre lookups.

### src/fetching/corpus_sampler.py
- Refactored `_process_book` to accept the `Book` type instead of a raw dictionary.
- Updated genre assignment to use the new `get_source_genres` function, ensuring consistent logic across different source types.

### Test Suite
- Standardized indentation to tabs in `test_corpus_sampler.py` and `test_text_splits.py`.
- Added a parameterized test suite for `get_source_genres` covering:
    - Gutenberg ID prefix removal.
    - Fallback logic for missing map entries.
    - Logic for non-Gutenberg sources.
- Updated `test_dataset_extractor.py` to verify ID prefixing for different source types.