### PR TITLE
convert.slurm script + tokenization and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,8 @@ __marimo__/
 /ciphers
 /data
 /temp_ciphers
+/logs
+/outputs
 
 # Books
 /books

--- a/convert.slurm
+++ b/convert.slurm
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH --job-name=convert_data
+#SBATCH --output=logs/convert_%j.out
+#SBATCH --error=logs/convert_%j.err
+#SBATCH --time=12:00:00
+#SBATCH --partition=l4      # Use a CPU partition (change 'cpu' if AAU uses a different name for CPU nodes)
+#SBATCH --cpus-per-task=32   # Grab 32 cores to rip through the files
+#SBATCH --mem=64G            # Plenty of memory to hold the paths
+
+set -e
+
+# Go to the directory where the script is
+cd /ceph/project/SW10-CausalLM/ciphertext_generation
+
+# Add uv to path if necessary
+export PATH="$HOME/.local/bin:$PATH"
+
+echo "Starting conversion $@..."
+uv run src/preprocess.py "$@"
+echo "Finished completely!"

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
             buildInputs = [
               python312
               uv
+              ruff
             ];
 
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,0 +1,220 @@
+import json
+import os
+import argparse
+import logging
+from datasets import Dataset, Features, Value
+from typing import Any, Generator
+from pathlib import Path
+from dataclasses import dataclass
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger("preprocess.py")
+
+
+@dataclass
+class Config:
+    """Config for arrow dataset creation."""
+
+    # 10k characters + BOS, EOS, SEP
+    max_context: int = 10_000 + 3
+    unique_homophones: int = 500
+    data_dir: Path = Path(__file__).parent.parent.parent / "Ciphers"
+    output_dir: Path = Path(__file__).parent.parent.parent / "outputs"
+    homophone_file: str = "metadata"
+    use_spaces: bool = False
+
+    @property
+    def final_output_dir(self) -> Path:
+        """Dynamic output dir to either outputs/spaces/ or outputs/normal/."""
+        suffix = "spaces" if self.use_spaces else "normal"
+        return self.output_dir / suffix
+
+    # TOKEN PROPERTIES
+    @property
+    def sep_token_id(self) -> int:
+        """Seperator token."""
+        return self.unique_homophones + 1
+
+    @property
+    def space_token_id(self) -> int:
+        """Space token."""
+        return self.sep_token_id + 1
+
+    @property
+    def bos_token_id(self) -> int:
+        """Beginning of sequence token."""
+        return self.space_token_id + 1
+
+    @property
+    def eos_token_id(self) -> int:
+        """End of sequence token."""
+        return self.bos_token_id + 1
+
+    @property
+    def char_offset(self) -> int:
+        """Character ofset to avoid clashes with defined tokens."""
+        return self.eos_token_id + 1
+
+    @property
+    def tokenized_dir(self) -> Path:
+        """Dynamic path based on whether we use spaces or not."""
+        suffix = "spaced" if self.use_spaces else "normal"
+        return self.data_dir / f"tokenized_{suffix}"
+
+    def load_homophones(self) -> None:
+        """Load the homophone metadata file and set the unique homophone count."""
+        homophone_path = os.path.join(self.data_dir, self.homophone_file)
+        if os.path.exists(homophone_path):
+            try:
+                with open(homophone_path) as f:
+                    meta = json.load(f)
+                    homophones = int(meta["max_symbol_id"])
+                    self.unique_homophones = homophones
+            except OSError as e:
+                logger.warning(f"Could not read file: {self.homophone_file}")
+                logger.warning(f"Using default value: {self.unique_homophones}")
+                logger.warning(f"Error: {e}")
+            except (ValueError, KeyError) as e:
+                logger.warning(f"Invalid or missing data in {self.homophone_file}")
+                logger.warning(f"Using default value: {self.unique_homophones}")
+                logger.warning(f"Error: {e}")
+
+features = Features(
+    {
+        "ciphertext": Value("string"),
+        "plaintext": Value("string"),
+        "ciphertext_with_boundaries": Value("string"),
+        "plaintext_with_boundaries": Value("string"),
+        "difficulty": Value("int32"),
+    },
+)
+
+
+class RawToArrowConverter:
+    """Encapsulates the tokenization logic for testing and execution."""
+
+    def __init__(self, config: Config) -> None:
+        """Initialize the converter with model configuration.
+
+        Args:
+                config (Config): The configuration object containing token offsets.
+
+        """
+        self.cfg = config
+        self.t_key = "plaintext_with_boundaries" if config.use_spaces else "plaintext"
+        self.c_key = "ciphertext_with_boundaries" if config.use_spaces else "ciphertext"
+
+    def tokenize_fn(self, example: dict[str, Any]) -> dict[str, Any]:
+        """Tokenize a single example from the dataset.
+
+        Args:
+                example (Dict[str, Any]): A raw dictionary of text and cipher strings.
+
+        Returns:
+                Dict[str, Any]: A dictionary containing 'input_ids' and 'labels'.
+
+        """
+        # Cipher mapping (splitting and handling _)
+        raw_cipher = example[self.c_key].split()
+        cipher_ids = [
+            self.cfg.space_token_id if x == "_" else int(x) for x in raw_cipher
+        ]
+
+        # Plaintext mapping (char by char)
+        plain_ids = []
+        for char in example[self.t_key]:
+            if char == "_":
+                plain_ids.append(self.cfg.space_token_id)
+            elif "a" <= char <= "z":
+                plain_ids.append(ord(char) - ord("a") + self.cfg.char_offset)
+
+        # BOS, EOS, SEP
+        special_tokens = [
+            self.cfg.bos_token_id,
+            self.cfg.sep_token_id,
+            self.cfg.eos_token_id,
+        ]
+        # max allowed length, but with room for special tokens
+        max_content_budget = self.cfg.max_context - len(special_tokens)
+        total_content_len = len(cipher_ids) + len(plain_ids)
+
+        if total_content_len > max_content_budget:
+            # cut equally if spaces makes the sequence longer than allowed
+            half_budget = max_content_budget // 2
+            cipher_ids = cipher_ids[:half_budget]
+            plain_ids = plain_ids[: (max_content_budget - len(cipher_ids))]
+
+        input_ids = (
+            [self.cfg.bos_token_id]
+            + cipher_ids
+            + [self.cfg.sep_token_id]
+            + plain_ids
+            + [self.cfg.eos_token_id]
+        )
+
+        labels = list(input_ids)
+
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "raw_plaintext": example[self.t_key],
+            "difficulty": example["difficulty"],
+        }
+
+
+def preprocess_data() -> None:
+    """Execute the entry point for preprocessing raw JSON data into Arrow format.
+
+    Parses CLI arguments, loads the configuration, and iterates through
+    data splits to save tokenized datasets to disk.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spaces", action="store_true")
+    args = parser.parse_args()
+
+    cfg = Config()
+    cfg.use_spaces = args.spaces
+    cfg.load_homophones()
+
+    # Initialize the converter
+    converter = RawToArrowConverter(cfg)
+
+    # Load Raw JSONs
+    for split in ["Training", "Test", "Validation"]:
+        logger.info("Converting %s (Spaces: %s)...", split, cfg.use_spaces)
+        split_path = cfg.data_dir / split
+        if not split_path.exists():
+            logger.warning(f"Split path {split_path} does not exist. Skipping.")
+            continue
+
+        logger.info(f"Processing {split} (Spaces: {cfg.use_spaces})...")
+
+        def gen(path: Path = split_path) -> Generator[dict[str, Any], None, None]:
+            for file_path in path.iterdir():
+                if file_path.suffix == ".json":
+                    with open(file_path) as f:
+                        yield json.load(f)
+
+        raw_ds = Dataset.from_generator(gen, features=features)
+
+        tokenized_ds = raw_ds.map(
+            converter.tokenize_fn,
+            num_proc=8,
+            remove_columns=[
+                "ciphertext",
+                "ciphertext_with_boundaries",
+                "plaintext",
+                "plaintext_with_boundaries",
+                "difficulty",
+            ],
+        )
+
+        save_path = cfg.tokenized_dir / split
+        tokenized_ds.save_to_disk(str(save_path))
+        logger.info("Saved to %s", save_path)
+
+
+if __name__ == "__main__":
+    preprocess_data()

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -18,7 +18,7 @@ SEQ_LEN = TEXT_LEN * 2 + 3
 @dataclass
 class Config:
     """Config for arrow dataset creation."""
-    
+
     # 10k*2 characters + BOS, EOS, SEP
     max_context: SEQ_LEN
     unique_homophones: int = 500

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -12,13 +12,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger("preprocess.py")
 
+TEXT_LEN = 10_000
+SEQ_LEN = TEXT_LEN * 2 + 3
 
 @dataclass
 class Config:
     """Config for arrow dataset creation."""
-
-    # 10k characters + BOS, EOS, SEP
-    max_context: int = 10_000 + 3
+    
+    # 10k*2 characters + BOS, EOS, SEP
+    max_context: SEQ_LEN
     unique_homophones: int = 500
     data_dir: Path = Path(__file__).parent.parent.parent / "Ciphers"
     output_dir: Path = Path(__file__).parent.parent.parent / "outputs"

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -8,19 +8,21 @@ from pathlib import Path
 from dataclasses import dataclass
 
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger("preprocess.py")
 
 TEXT_LEN = 10_000
 SEQ_LEN = TEXT_LEN * 2 + 3
 
+
 @dataclass
 class Config:
     """Config for arrow dataset creation."""
 
     # 10k*2 characters + BOS, EOS, SEP
-    max_context: SEQ_LEN
+    max_context: int = SEQ_LEN
     unique_homophones: int = 500
     data_dir: Path = Path(__file__).parent.parent.parent / "Ciphers"
     output_dir: Path = Path(__file__).parent.parent.parent / "outputs"
@@ -82,6 +84,7 @@ class Config:
                 logger.warning(f"Invalid or missing data in {self.homophone_file}")
                 logger.warning(f"Using default value: {self.unique_homophones}")
                 logger.warning(f"Error: {e}")
+
 
 features = Features(
     {

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -92,7 +92,7 @@ features = Features(
         "plaintext": Value("string"),
         "ciphertext_with_boundaries": Value("string"),
         "plaintext_with_boundaries": Value("string"),
-        "difficulty": Value("int32"),
+        "redundancy": Value("int32"),
     },
 )
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -58,7 +58,7 @@ class Config:
 
     @property
     def char_offset(self) -> int:
-        """Character ofset to avoid clashes with defined tokens."""
+        """Character offset to avoid clashes with defined tokens."""
         return self.eos_token_id + 1
 
     @property
@@ -165,7 +165,6 @@ class RawToArrowConverter:
             "input_ids": input_ids,
             "labels": labels,
             "raw_plaintext": example[self.t_key],
-            "difficulty": example["difficulty"],
         }
 
 
@@ -196,13 +195,16 @@ def preprocess_data() -> None:
 
         logger.info(f"Processing {split} (Spaces: {cfg.use_spaces})...")
 
-        def gen(path: Path = split_path) -> Generator[dict[str, Any], None, None]:
-            for file_path in path.iterdir():
-                if file_path.suffix == ".json":
-                    with open(file_path) as f:
-                        yield json.load(f)
+        raw_ds = Dataset.from_generator(
+            _json_generator,
+            gen_kwargs={"path": split_path},
+            features=features,
+        )
 
-        raw_ds = Dataset.from_generator(gen, features=features)
+        if not isinstance(raw_ds, Dataset):
+            raise TypeError(
+                f"Expected a Dataset from the generator, but got {type(raw_ds)}.",
+            )
 
         tokenized_ds = raw_ds.map(
             converter.tokenize_fn,
@@ -212,13 +214,19 @@ def preprocess_data() -> None:
                 "ciphertext_with_boundaries",
                 "plaintext",
                 "plaintext_with_boundaries",
-                "difficulty",
             ],
         )
 
         save_path = cfg.tokenized_dir / split
         tokenized_ds.save_to_disk(str(save_path))
         logger.info("Saved to %s", save_path)
+
+
+def _json_generator(path: Path) -> Generator[dict[str, Any], None, None]:
+    for file_path in path.iterdir():
+        if file_path.suffix == ".json":
+            with open(file_path, encoding="utf-8") as f:
+                yield json.load(f)
 
 
 if __name__ == "__main__":

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -1,0 +1,62 @@
+import pytest
+from preprocess import RawToArrowConverter, Config
+
+
+@pytest.fixture
+def sample_payload():
+    """Provide a sample dictionary as it would appear when loaded from JSON."""
+    return {
+        "ciphertext": "1 2",
+        "plaintext": "ab",
+        "ciphertext_with_boundaries": "1 _ 2",
+        "plaintext_with_boundaries": "a _ b",
+        "difficulty": 20,
+    }
+
+
+def test_mapping_logic_no_spaces(sample_payload):
+    # Set unique_homophones=10 to lock the special tokens to the expected IDs
+    cfg = Config(unique_homophones=10, use_spaces=False)
+    converter = RawToArrowConverter(cfg)
+    
+    result = converter.tokenize_fn(sample_payload)
+    ids = result["input_ids"]
+
+    # [BOS] + [1, 2] + [SEP] + [15, 16] + [EOS]
+    assert ids == [13, 1, 2, 11, 15, 16, 14]
+    
+    # Verify joint distribution labels match inputs exactly
+    assert result["labels"] == ids
+
+
+def test_mapping_logic_with_spaces(sample_payload):
+    cfg = Config(unique_homophones=10, use_spaces=True)
+    converter = RawToArrowConverter(cfg)
+    
+    result = converter.tokenize_fn(sample_payload)
+    ids = result["input_ids"]
+
+    # Expected: [BOS] + [1, SPACE, 2] + [SEP] + [15, SPACE, 16] + [EOS]
+    assert ids == [13, 1, 12, 2, 11, 15, 12, 16, 14]
+
+
+def test_smart_truncation_limits_content(sample_payload):
+    cfg = Config(unique_homophones=10, use_spaces=False)
+    
+    # Payload has 2 cipher tokens + 2 plain tokens = 4 content tokens.
+    # We force max_context to 5. 
+    # With 3 special tokens (BOS, SEP, EOS), the content budget is only 2.
+    cfg.max_context = 5 
+    
+    converter = RawToArrowConverter(cfg)
+    result = converter.tokenize_fn(sample_payload)
+    ids = result["input_ids"]
+
+    # Budget is 2. The 50/50 split means Cipher gets 1 token, Plain gets 1 token.
+    # Cipher: "1" -> 1
+    # Plain: "a" -> 15
+    # Expected: [BOS] + [1] + [SEP] + [15] + [EOS]
+    assert ids == [13, 1, 11, 15, 14]
+    
+    # Mathematically guarantee the truncation logic respects the hard ceiling
+    assert len(ids) == cfg.max_context

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -18,13 +18,13 @@ def test_mapping_logic_no_spaces(sample_payload):
     # Set unique_homophones=10 to lock the special tokens to the expected IDs
     cfg = Config(unique_homophones=10, use_spaces=False)
     converter = RawToArrowConverter(cfg)
-    
+
     result = converter.tokenize_fn(sample_payload)
     ids = result["input_ids"]
 
     # [BOS] + [1, 2] + [SEP] + [15, 16] + [EOS]
     assert ids == [13, 1, 2, 11, 15, 16, 14]
-    
+
     # Verify joint distribution labels match inputs exactly
     assert result["labels"] == ids
 
@@ -32,7 +32,7 @@ def test_mapping_logic_no_spaces(sample_payload):
 def test_mapping_logic_with_spaces(sample_payload):
     cfg = Config(unique_homophones=10, use_spaces=True)
     converter = RawToArrowConverter(cfg)
-    
+
     result = converter.tokenize_fn(sample_payload)
     ids = result["input_ids"]
 
@@ -42,12 +42,12 @@ def test_mapping_logic_with_spaces(sample_payload):
 
 def test_smart_truncation_limits_content(sample_payload):
     cfg = Config(unique_homophones=10, use_spaces=False)
-    
+
     # Payload has 2 cipher tokens + 2 plain tokens = 4 content tokens.
-    # We force max_context to 5. 
+    # We force max_context to 5.
     # With 3 special tokens (BOS, SEP, EOS), the content budget is only 2.
-    cfg.max_context = 5 
-    
+    cfg.max_context = 5
+
     converter = RawToArrowConverter(cfg)
     result = converter.tokenize_fn(sample_payload)
     ids = result["input_ids"]
@@ -57,6 +57,6 @@ def test_smart_truncation_limits_content(sample_payload):
     # Plain: "a" -> 15
     # Expected: [BOS] + [1] + [SEP] + [15] + [EOS]
     assert ids == [13, 1, 11, 15, 14]
-    
+
     # Mathematically guarantee the truncation logic respects the hard ceiling
     assert len(ids) == cfg.max_context

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -10,7 +10,7 @@ def sample_payload():
         "plaintext": "ab",
         "ciphertext_with_boundaries": "1 _ 2",
         "plaintext_with_boundaries": "a _ b",
-        "difficulty": 20,
+        "redundancy": 20,
     }
 
 


### PR DESCRIPTION
This pull request introduces a new, robust preprocessing pipeline for converting raw JSON cipher/plaintext data into Arrow datasets, including a fully configurable setup, smart token mapping and truncation, and comprehensive tests. It also adds a Slurm job script for batch processing and updates the development environment to include `ruff` for linting.

**Preprocessing pipeline and dataset conversion:**

* Introduced `src/preprocess.py`, which implements a configurable `Config` dataclass, a `RawToArrowConverter` class for tokenization, and a main routine to process raw cipher data into Arrow datasets with smart truncation, special token handling, and support for both spaced and normal modes. The pipeline logs progress, reads metadata for dynamic token assignments, and saves tokenized datasets for each split.

* Added `test/test_preprocess.py` with tests to verify token mapping logic (with and without spaces) and to ensure the truncation logic respects the maximum context limit, increasing reliability and maintainability.

**Infrastructure and environment improvements:**

* Added `convert.slurm`, a Slurm batch script to automate preprocessing jobs with resource allocation and logging, making large-scale data conversion reproducible and efficient.

* Updated `flake.nix` to include `ruff` in the development environment, enabling code linting for improved code quality.