### PR TITLE
Fix process truncated data

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ To process the data without spaces:
 uv run src/preprocess.py
 ```
 
+#### Using slurm
+```bash
+sbatch convert.slurm --spaces --task causal --folder Truncated_4000
+```
+
+```bash
+sbatch convert.slurm --task mapping --folder Truncated_4000
+```
+
 ## JSON Data Structure
 
 Each generated cipher is saved as a JSON object with the following structure:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -4,6 +4,7 @@ import zipfile
 import os
 import argparse
 import logging
+import ast
 from datasets import Dataset, Features, Value
 from typing import Any, Generator
 from pathlib import Path
@@ -316,7 +317,11 @@ def _yield_from_zip(zip_path: Path) -> Generator[dict[str, Any], None, None]:
             with z.open(filename) as f:
                 for line in f:
                     if line.strip():
-                        yield orjson.loads(line)
+                        try:
+                            yield orjson.loads(line)
+                        except orjson.JSONDecodeError:
+                            # Fallback if the data is a Python dict string
+                            yield ast.literal_eval(line.decode("utf-8").strip())
 
 
 def _yield_from_jsonl(jsonl_path: Path) -> Generator[dict[str, Any], None, None]:
@@ -324,7 +329,11 @@ def _yield_from_jsonl(jsonl_path: Path) -> Generator[dict[str, Any], None, None]
     with open(jsonl_path, "rb") as f:
         for line in f:
             if line.strip():
-                yield orjson.loads(line)
+                try:
+                    yield orjson.loads(line)
+                except orjson.JSONDecodeError:
+                    # Fallback if the data is a Python dict string
+                    yield ast.literal_eval(line.decode("utf-8").strip())
 
 
 def _json_generator(path: Path) -> Generator[dict[str, Any], None, None]:


### PR DESCRIPTION
This pull request adds support for running the preprocessing script with Slurm and improves the robustness of JSON parsing in `src/preprocess.py` by adding a fallback for malformed JSON lines. The most important changes are:

**Documentation updates:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R77-R85): Added instructions for using Slurm to run the preprocessing script, including example `sbatch` commands.

**Robustness improvements:**

* [`src/preprocess.py`](diffhunk://#diff-bd9e96c493451832606e3dc0db09cecbfff190c255d509ff73ec2c8a5e62321cR320-R336): In both `_yield_from_zip` and `_yield_from_jsonl`, added a fallback to parse lines with `ast.literal_eval` if `orjson` fails, making the script more tolerant to lines that are Python dict strings instead of strict JSON.

**Dependency updates:**

* [`src/preprocess.py`](diffhunk://#diff-bd9e96c493451832606e3dc0db09cecbfff190c255d509ff73ec2c8a5e62321cR7): Added `import ast` to support the new fallback parsing logic.